### PR TITLE
Fix some references

### DIFF
--- a/TimeSeries.tex
+++ b/TimeSeries.tex
@@ -122,17 +122,17 @@ Light curves at different wavelength provide different information allowing a be
 \label{elem:TIMESERIES}
 This document proposes the minimum metadata in VOTables to describe time series. We assume that the tabular data can contain multiple rows for each astronomical source and for mixed types of time series (e.~g. different filters, positions, radial velocities) and sometimes even include different types of data (e.~g. spectra, or images). 
 
-We propose using some elements previously defined, such as \elem{TIMESYS} and \elem{COOSYS} (when applicable) in VOTable1.4 \citet{std:VOTABLE1.4} and define a set of new elements as well as how to structure these elements. The aim is to be able to combine multiple time series when they have common elements as described in this document. We define a \elem{GROUP} element called \elem{PHOTCAL} following the same type of structure. If these elements were to be added or modified in future versions of VOTable it should be straight forward to update this document. This note is inspired by a previous annotation strategy developed for annotating photometric data in VOTables \citep{note:seb2010-1}.
+We propose using some elements previously defined, such as \elem{TIMESYS} and \elem{COOSYS} (when applicable) in VOTable starting from version~1.4 \citep{2019ivoa.spec.1021O} and define a set of new elements as well as how to structure these elements. The aim is to be able to combine multiple time series when they have common elements as described in this document. We define a \elem{GROUP} element called \elem{PHOTCAL} following the same type of structure. If these elements were to be added or modified in future versions of VOTable it should be straight forward to update this document. This note is inspired by a previous annotation strategy developed for annotating photometric data in VOTables \citep{note:seb2010-1}.
 
 %\input{timesys.tex}
 %\input{coosys.tex}
 
 \subsection{\elem{PHOTCAL} Element}
-\elem{PHOTCAL} contains information on the photometric system of the observations. This element is partially asociated to the intermediate class PhotCal of the Photometry Data Model \citep{std:PDM}. A service providing time series of the type light-curve (e.~g. magnitudes, fluxes) \textbf{MUST} provide this element. To reference the photometric system defined by a \elem{PHOTCAL} element, \elem{FIELD}s (and possibly \elem{PARAM}s) \textbf{MUST} reference the \elem{PHOTCAL} using the VOTable \attr{ref} attribute. A \elem{PHOTCAL} element referenced via a \attr{ref} attribute \textbf{SHOULD} appear before the element that references it. 
+\elem{PHOTCAL} contains information on the photometric system of the observations. This element is partially asociated to the intermediate class PhotCal of the Photometry Data Model \citep{2013ivoa.spec.1005S}. A service providing time series of the type light-curve (e.~g. magnitudes, fluxes) \textbf{MUST} provide this element. To reference the photometric system defined by a \elem{PHOTCAL} element, \elem{FIELD}s (and possibly \elem{PARAM}s) \textbf{MUST} reference the \elem{PHOTCAL} using the VOTable \attr{ref} attribute. A \elem{PHOTCAL} element referenced via a \attr{ref} attribute \textbf{SHOULD} appear before the element that references it. 
 
 Each \elem{PHOTCAL} is defined as a \elem{GROUP} with the following mandatory terms:
 \begin{description}
-     \item[\attrval{name}{PHOTCAL}] The name of the \elem{GROUP} \textbf{MUST} be set to \verb|PHOTCAL|. We realize that although this proposed usage of the \attr{name} is not common, it is not forbidden by VOTable \cite[][see Section 3.2]{std:VOTABLE1.4}, and in this context it will help clients interpret the contents of the \elem{GROUP}. 
+     \item[\attrval{name}{PHOTCAL}] The name of the \elem{GROUP} \textbf{MUST} be set to \verb|PHOTCAL|. We realize that although this proposed usage of the \attr{name} is not common, it is not forbidden by VOTable (\citet{2019ivoa.spec.1021O}, section 3.2), and in this context it will help clients interpret the contents of the \elem{GROUP}. 
      \item[\attr{ID}] This attribute is used to reference the \elem{PHOTCAL} \elem{GROUP} from the elements using the photometric system. This attribute needs to be unique within the document so that it can be referenced by \elem{FIELD}s and is mandatory.
      \item[\attr{DESCRIPTION}] This attribute is used to describe the \elem{PHOTCAL} \elem{GROUP}. This attribute is optional, but recommended.
      \item[\attrval{utype}{timeseries:PhotometryPoint}]
@@ -196,7 +196,7 @@ For other type of time series data not explicitly defined in this document we re
 %\input{GROUP.tex}
 \subsection{\elem{TABLE}}
 %\todo{We could propose to define one \elem{TABLE} element to describe the content of each timeseries with common metadata (e.~g. one per filter) with no \elem{DATA}, and to add in a separate \elem{TABLE} element the \elem{DATA} part wich will referece the approprate \elem{TABLE} element. But to be honest I am not sure about the pros and contras of that at the moment of writing.} 
-We propose to use the \elem{TABLE} element for describing the contents of the time series data itself. One \elem{TABLE} element MUST be present for each \elem{PHOTCAL} \elem{GROUP} element defined. We also propose to annotate the \elem{TABLE} as a timeseries using \elem{PARAM}s defined as elements from Obscore \citep{std:OBSCORE1.1}.   
+We propose to use the \elem{TABLE} element for describing the contents of the time series data itself. One \elem{TABLE} element MUST be present for each \elem{PHOTCAL} \elem{GROUP} element defined. We also propose to annotate the \elem{TABLE} as a timeseries using \elem{PARAM}s defined as elements from Obscore \citep{2017ivoa.spec.0509L}.
 The \elem{TABLE} must include: 
 \begin{description}
      \item[\attr{DESCRIPTION}] Human readable text describing the time series. This element is mandatory. 
@@ -227,7 +227,7 @@ The \elem{TABLE} must include:
 
 \input{table_TIMESERIES.tex}
 
-We explored other ways of annotating the data, for instance defining different tables and the relation between them using foreignKey as possible according to Section 4.10 of VOTable \citep{std:VOTABLE1.4}, or even proposing a new XMLDATA serialization. After exploring those possibilities we conclude that the proposed solution is the most appropriate within the actual and most accepted usage of VOTablefor both existing data providers and clients.
+We explored other ways of annotating the data, for instance defining different tables and the relation between them using foreignKey as possible according to Section 4.10 of VOTable \citep{2019ivoa.spec.1021O}, or even proposing a new XMLDATA serialization. After exploring those possibilities we conclude that the proposed solution is the most appropriate within the actual and most accepted usage of VOTablefor both existing data providers and clients.
 
 \section{Example of VOTable serialization}
 \subsection{Case 1: lightcurves in one filter}
@@ -257,13 +257,13 @@ In those cases this complicates the annotation and the need of being able to ref
 %To avoid referencing columns, which would make things a bit more complicated, we propose to create different \elem{TABLE} elements, one for each filter. This, although reduntant in the definition of some of the columns, will ease combining timeseries from the client side. 
 
 %Alternative 2: Use the GROUP name=key thing and a different table to define the relation between elements. This 
-%Alternative 3: Another possible solution would be to create a new XMLDATA serialization which would allow to tag rows, as proposed in Appendix A.8 of \cite{std:VOTABLE1.4}. But wouldn't that break the interoperability? 
+%Alternative 3: Another possible solution would be to create a new XMLDATA serialization which would allow to tag rows, as proposed in Appendix A.8 of \citet{2019ivoa.spec.1021O}. But wouldn't that break the interoperability? 
 
 
 %\todo{Do we have to say something about claiming a new capability in the registry? }
 %\todo{Do we want to add a summary table with utype, UCD1+, Meaning, Default value, Data type, required?} 
 
 %\input{timeseriesDM.tex}
-\bibliography{ivoatex/ivoabib,ivoatex/docrepo,TimeSeries}
+\bibliography{ivoatex/ivoabib,ivoatex/docrepo}
 
 \end{document}

--- a/ivoatex/docrepo.bib
+++ b/ivoatex/docrepo.bib
@@ -1,1428 +1,1558 @@
-Query Results from the ADS Database
+@MISC{2020ivoa.spec.0411S,
+       author = {{Servillat}, Mathieu and {Riebe}, Kristin and {Boisson}, Catherine and
+         {Bonnarel}, Fran{\c{c}}ois and {Galkin}, Anastasia and
+         {Louys}, Mireille and {Nullmeier}, Markus and
+         {Renault-Tinacci}, Nicolas and {Sanguillon}, Mich{\`e}le and
+         {Streicher}, Ole},
+        title = "{IVOA Provenance Data Model Version 1.0}",
+ howpublished = {IVOA Recommendation 11 April 2020},
+         year = 2020,
+        month = apr,
+        pages = {411},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020ivoa.spec.0411S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
+@MISC{2019ivoa.spec.1021O,
+       author = {{Ochsenbein}, Francois and {Taylor}, Mark and {Donaldson}, Tom and
+         {Williams}, Roy and {Davenhall}, Clive and {Demleitner}, Markus and
+         {Durand}, Daniel and {Fernique}, Pierre and {Giaretta}, David and
+         {Hanisch}, Robert and {McGlynn}, Tom and {Szalay}, Alex and
+         {Wicenec}, Andreas},
+        title = "{VOTable Format Definition Version 1.4}",
+ howpublished = {IVOA Recommendation 21 October 2019},
+         year = 2019,
+        month = oct,
+        pages = {1021},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ivoa.spec.1021O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
-Retrieved 97 abstracts, starting with number 1.  Total number selected: 97.
+@MISC{2019ivoa.spec.1011D,
+       author = {{Demleitner}, Markus and {Harrison}, Paul and {Molinaro}, Marco and
+         {Greene}, Gretchen and {Dower}, Theresa and {Perdikeas}, Menelaos},
+        title = "{IVOA Registry Relational Schema Version 1.1}",
+ howpublished = {IVOA Recommendation 11 October 2019},
+         year = 2019,
+        month = oct,
+        pages = {1011},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ivoa.spec.1011D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@MISC{2019ivoa.spec.1007F,
+       author = {{Fernique}, Pierre and {Boch}, Thomas and {Donaldson}, Tom and {Durand
+        }, Daniel and {O'Mullane}, Wil and {Reinecke}, Martin and {Taylor}, Mark},
+        title = "{MOC - HEALPix Multi-Order Coverage map Version 1.1}",
+ howpublished = {IVOA Recommendation 07 October 2019},
+         year = 2019,
+        month = oct,
+        pages = {1007},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ivoa.spec.1007F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@MISC{2019ivoa.spec.0927D,
+       author = {{Dowler}, Patrick and {Rixon}, Guy and {Tody}, Doug and
+         {Demleitner}, Markus},
+        title = "{Table Access Protocol Version 1.1}",
+ howpublished = {IVOA Recommendation 27 September 2019},
+         year = 2019,
+        month = sep,
+        pages = {927},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ivoa.spec.0927D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @MISC{2019ivoa.rept.0520D,
-   author = {{Demleitner}, M. and {Taylor}, M.},
-    title = "{Discovering Data Collections Within Services Version 1.1}",
-howpublished = {IVOA Note 20 May 2019},
-     year = 2019,
-    month = may,
-   editor = {{Demleitner}, M.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2019ivoa.rept.0520D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, Markus and {Taylor}, Mark},
+        title = "{Discovering Data Collections Within Services Version 1.1}",
+ howpublished = {IVOA Note 20 May 2019},
+         year = 2019,
+        month = may,
+        pages = {520},
+          doi = {10.5479/ADS/bib/2019ivoa.rept.0520D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ivoa.rept.0520D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2018ivoa.spec.0910L,
-   author = {{Lemson}, G. and {Laurino}, O. and {Bourges}, L. and {Cresitello-Dittmar}, M. and 
-	{Demleitner}, M. and {Donaldson}, T. and {Dowler}, P. and {Graham}, M. and 
-	{Gray}, N. and {Michel}, L. and {Salgado}, J.},
-    title = "{VO-DML: a consistent modeling language for IVOA data models Version 1.0}",
-howpublished = {IVOA Recommendation 10 September 2018},
-     year = 2018,
-    month = sep,
-   editor = {{Lemson}, G. and {Laurino}, O.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0910L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Lemson}, Gerard and {Laurino}, Omar and {Bourges}, Laurent and
+         {Cresitello-Dittmar}, Mark and {Demleitner}, Markus and
+         {Donaldson}, Tom and {Dowler}, Patrick and {Graham}, Matthew and
+         {Gray}, Norman and {Michel}, Laurent and {Salgado}, Jesus},
+        title = "{VO-DML: a consistent modeling language for IVOA data models Version 1.0}",
+ howpublished = {IVOA Recommendation 10 September 2018},
+         year = 2018,
+        month = sep,
+        pages = {910},
+          doi = {10.5479/ADS/bib/2018ivoa.spec.0910L},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0910L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2018ivoa.spec.0723D,
-   author = {{Dower}, T. and {Demleitner}, M. and {Benson}, K. and {Plante}, R. and 
-	{Auden}, E. and {Graham}, M. and {Greene}, G. and {Hill}, M. and 
-	{Linde}, T. and {Morris}, D. and {O`Mullane}, W. and {Rixon}, G. and 
-	{St{\'e}b{\'e}}, A. and {Andrews}, K.},
-    title = "{Registry Interfaces Version 1.1}",
-howpublished = {IVOA Recommendation 23 July 2018},
-     year = 2018,
-    month = jul,
-   editor = {{Dower}, T. and {Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2018ivoa.spec.0723D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0723D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Dower}, Theresa and {Demleitner}, Markus and {Benson}, Kevin and
+         {Plante}, Ray and {Auden}, Elizabeth and {Graham}, Matthew and
+         {Greene}, Gretchen and {Hill}, Martin and {Linde}, Tony and
+         {Morris}, Dave and {O`Mullane}, Wil and {Rixon}, Guy and
+         {St{\'e}b{\'e}}, Aur{\'e}lien and {Andrews}, Kona},
+        title = "{Registry Interfaces Version 1.1}",
+ howpublished = {IVOA Recommendation 23 July 2018},
+         year = 2018,
+        month = jul,
+        pages = {723},
+          doi = {10.5479/ADS/bib/2018ivoa.spec.0723D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0723D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2018ivoa.spec.0625P,
-   author = {{Plante}, R. and {Demleitner}, M. and {Benson}, K. and {Graham}, M. and 
-	{Greene}, G. and {Harrison}, P. and {Lemson}, G. and {Linde}, T. and 
-	{Rixon}, G.},
-    title = "{VOResource: an XML Encoding Schema for Resource Metadata Version 1.1}",
-howpublished = {IVOA Recommendation 25 June 2018},
-     year = 2018,
-    month = jun,
-   editor = {{Plante}, R. and {Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2018ivoa.spec.0625P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0625P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {Demleitner}, Markus and {Benson}, Kevin and
+         {Graham}, Matthew and {Greene}, Gretchen and {Harrison}, Paul and
+         {Lemson}, Gerard and {Linde}, Tony and {Rixon}, Guy},
+        title = "{VOResource: an XML Encoding Schema for Resource Metadata Version 1.1}",
+ howpublished = {IVOA Recommendation 25 June 2018},
+         year = 2018,
+        month = jun,
+        pages = {625},
+          doi = {10.5479/ADS/bib/2018ivoa.spec.0625P},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0625P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2018ivoa.spec.0621G,
-   author = {{Graham}, M. and {Major}, B. and {Morris}, D. and {Rixon}, G. and 
-	{Dowler}, P. and {Schaaff}, A. and {Tody}, D.},
-    title = "{VOSpace Version 2.1}",
-howpublished = {IVOA Recommendation 21 June 2018},
-     year = 2018,
-    month = jun,
-   editor = {{Graham}, M. and {Major}, B.},
-      doi = {10.5479/ADS/bib/2018ivoa.spec.0621G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0621G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Major}, Brian and {Morris}, Dave and
+         {Rixon}, Guy and {Dowler}, Pat and {Schaaff}, Andr{\'e} and
+         {Tody}, Doug},
+        title = "{VOSpace Version 2.1}",
+ howpublished = {IVOA Recommendation 21 June 2018},
+         year = 2018,
+        month = jun,
+        pages = {621},
+          doi = {10.5479/ADS/bib/2018ivoa.spec.0621G},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0621G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2018ivoa.spec.0529H,
-   author = {{Harrison}, P. and {Demleitner}, M. and {Major}, B. and {Dowler}, P.
-	},
-    title = "{XML Schema Versioning Policies Version 1.0}",
-howpublished = {IVOA Endorsed Note 29 May 2018},
-     year = 2018,
-    month = may,
-   editor = {{Harrison}, P.},
-      doi = {10.5479/ADS/bib/2018ivoa.spec.0529H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0529H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Harrison}, Paul and {Demleitner}, Markus and {Major}, Brian and
+         {Dowler}, Pat},
+        title = "{XML Schema Versioning Policies Version 1.0}",
+ howpublished = {IVOA Endorsed Note 29 May 2018},
+         year = 2018,
+        month = may,
+        pages = {529},
+          doi = {10.5479/ADS/bib/2018ivoa.spec.0529H},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0529H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2018ivoa.spec.0527M,
-   author = {{Martinez}, A.~P. and {Louys}, M. and {Cecconi}, B. and {Derriere}, S. and 
-	{Ochsenbein}, F. and {IVOA Semantic Working Group}},
-    title = "{The UCD1+ controlled vocabulary Version 1.3 Version 1.3}",
-howpublished = {IVOA Recommendation 27 May 2018},
-     year = 2018,
-    month = may,
-   editor = {{Martinez}, A.~P. and {Louys}, M.},
-      doi = {10.5479/ADS/bib/2018ivoa.spec.0527M},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0527M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Martinez}, Andrea Preite and {Louys}, Mireille and {Cecconi}, Baptiste and
+         {Derriere}, Sebastien and {Ochsenbein}, Fran{\c{c}}ois and
+         {IVOA Semantic Working Group}},
+        title = "{The UCD1+ controlled vocabulary Version 1.3 Version 1.3}",
+ howpublished = {IVOA Recommendation 27 May 2018},
+         year = 2018,
+        month = may,
+        pages = {527},
+          doi = {10.5479/ADS/bib/2018ivoa.spec.0527M},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2018ivoa.spec.0527M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0530P,
-   author = {{Plante}, R. and {Demleitner}, M. and {Plante}, R. and {Delago}, J. and 
-	{Harrison}, P. and {Tody}, D.},
-    title = "{Describing Simple Data Access Services Version 1.1}",
-howpublished = {IVOA Recommendation 30 May 2017},
-     year = 2017,
-    month = may,
-   editor = {{Plante}, R. and {Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2017ivoa.spec.0530P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0530P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Ray and {Demleitner}, Markus and {Plante}, Raymond and
+         {Delago}, Jesus and {Harrison}, Paul and {Tody}, Doug},
+        title = "{Describing Simple Data Access Services Version 1.1}",
+ howpublished = {IVOA Recommendation 30 May 2017},
+         year = 2017,
+        month = may,
+        pages = {530},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0530P},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0530P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0524T,
-   author = {{Taffoni}, G. and {Schaaf}, A. and {Rixon}, G. and {Major}, B.
-	},
-    title = "{SSO - Single-Sign-On Profile: Authentication Mechanisms Version 2.0}",
-howpublished = {IVOA Recommendation 24 May 2017},
-     year = 2017,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1709.00171},
- primaryClass = "astro-ph.IM",
-   editor = {{Taffoni}, G.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0524T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Taffoni}, Giuliano and {Schaaf}, Andr{\'e} and {Rixon}, Guy and
+         {Major}, Brian},
+        title = "{SSO - Single-Sign-On Profile: Authentication Mechanisms Version 2.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 24 May 2017},
+         year = 2017,
+        month = may,
+        pages = {524},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0524T},
+archivePrefix = {arXiv},
+       eprint = {1709.00171},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0524T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0524G,
-   author = {{Graham}, M. and {Rixon}, G. and {Dowler}, P. and {Major}, B. and 
-	{Grid} and {Web Services Working Group}},
-    title = "{IVOA Support Interfaces Version 1.1}",
-howpublished = {IVOA Recommendation 24 May 2017},
-     year = 2017,
-    month = may,
-   editor = {{Graham}, M. and {Rixon}, G. and {Dowler}, P. and {Major}, B.
-	},
-      doi = {10.5479/ADS/bib/2017ivoa.spec.0524G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0524G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Rixon}, Guy and {Dowler}, Patrick and
+         {Major}, Brian and {Grid} and {Web Services Working Group}},
+        title = "{IVOA Support Interfaces Version 1.1}",
+ howpublished = {IVOA Recommendation 24 May 2017},
+         year = 2017,
+        month = may,
+        pages = {524},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0524G},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0524G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0519F,
-   author = {{Fernique}, P. and {Allen}, M. and {Boch}, T. and {Donaldson}, T. and 
-	{Durand}, D. and {Ebisawa}, K. and {Michel}, L. and {Salgado}, J. and 
-	{Stoehr}, F.},
-    title = "{HiPS - Hierarchical Progressive Survey Version 1.0}",
-howpublished = {IVOA Recommendation 19 May 2017},
-     year = 2017,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1708.09704},
- primaryClass = "astro-ph.IM",
-   editor = {{Fernique}, P.},
-      doi = {10.5479/ADS/bib/2017ivoa.spec.0519F},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0519F},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Fernique}, Pierre and {Allen}, Mark and {Boch}, Thomas and
+         {Donaldson}, Tom and {Durand}, Daniel and {Ebisawa}, Ken and
+         {Michel}, Laurent and {Salgado}, Jesus and {Stoehr}, Felix},
+        title = "{HiPS - Hierarchical Progressive Survey Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 19 May 2017},
+         year = 2017,
+        month = may,
+        pages = {519},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0519F},
+archivePrefix = {arXiv},
+       eprint = {1708.09704},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0519F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0517G,
-   author = {{Genova}, F. and {Arviset}, C. and {Demleitner}, M. and {Glendenning}, B. and 
-	{Molinaro}, M. and {Hanisch}, R.~J. and {Rino}, B.},
-    title = "{IVOA Document Standards Version 2.0}",
-howpublished = {IVOA Recommendation 17 May 2017},
-     year = 2017,
-    month = may,
-   editor = {{Genova}, F.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0517G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Genova}, F. and {Arviset}, C. and {Demleitner}, M. and
+         {Glendenning}, B. and {Molinaro}, M. and {Hanisch}, R.~J. and
+         {Rino}, B.},
+        title = "{IVOA Document Standards Version 2.0}",
+ howpublished = {IVOA Recommendation 17 May 2017},
+         year = 2017,
+        month = may,
+        pages = {517},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0517G},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0517G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0517D,
-   author = {{Dowler}, P. and {Demleitner}, M. and {Taylor}, M. and {Tody}, D.
-	},
-    title = "{Data Access Layer Interface Version 1.1}",
-howpublished = {IVOA Recommendation 17 May 2017},
-     year = 2017,
-    month = may,
-   editor = {{Dowler}, P.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0517D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Dowler}, Patrick and {Demleitner}, Markus and {Taylor}, Mark and
+         {Tody}, Doug},
+        title = "{Data Access Layer Interface Version 1.1}",
+ howpublished = {IVOA Recommendation 17 May 2017},
+         year = 2017,
+        month = may,
+        pages = {517},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0517D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0517D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0517B,
-   author = {{Bonnarel}, F. and {Dowler}, P. and {Demleitner}, M. and {Tody}, D. and 
-	{Dempsey}, J.},
-    title = "{IVOA Server-side Operations for Data Access Version 1.0}",
-howpublished = {IVOA Recommendation 17 May 2017},
-     year = 2017,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1710.08791},
- primaryClass = "astro-ph.IM",
-   editor = {{Bonnarel}, F. and {Dowler}, P.},
-      doi = {10.5479/ADS/bib/2017ivoa.spec.0517B},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0517B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Bonnarel}, Fran{\c{c}}ois and {Dowler}, Patrick and
+         {Demleitner}, Markus and {Tody}, Douglas and {Dempsey}, James},
+        title = "{IVOA Server-side Operations for Data Access Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 17 May 2017},
+         year = 2017,
+        month = may,
+        pages = {517},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0517B},
+archivePrefix = {arXiv},
+       eprint = {1710.08791},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0517B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0509L,
-   author = {{Louys}, M. and {Tody}, D. and {Dowler}, P. and {Durand}, D. and 
-	{Michel}, L. and {Bonnarel}, F. and {Micol}, A. and {IVOA DataModel Working Group}
-	},
-    title = "{Observation Data Model Core Components, its Implementation in the Table Access Protocol Version 1.1}",
-howpublished = {IVOA Recommendation 09 May 2017},
-     year = 2017,
-    month = may,
-   editor = {{Louys}, M. and {Tody}, D. and {Dowler}, P. and {Durand}, D.
-	},
-      doi = {10.5479/ADS/bib/2017ivoa.spec.0509L},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0509L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Louys}, Mireille and {Tody}, Doug and {Dowler}, Patrick and {Durand
+        }, Daniel and {Michel}, Laurent and {Bonnarel}, Francos and
+         {Micol}, Alberto and {IVOA DataModel Working Group}},
+        title = "{Observation Data Model Core Components, its Implementation in the Table Access Protocol Version 1.1}",
+ howpublished = {IVOA Recommendation 09 May 2017},
+         year = 2017,
+        month = may,
+        pages = {509},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0509L},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0509L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0320S,
-   author = {{Swinbank}, J.~D. and {Allan}, A. and {Denny}, R.~B.},
-    title = "{VOEvent Transport Protocol Version 2.0}",
-howpublished = {IVOA Recommendation 20 March 2017},
-     year = 2017,
-    month = mar,
-   editor = {{Swinbank}, J.~D.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0320S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Swinbank}, John D. and {Allan}, Alasdair and {Denny}, Robert B.},
+        title = "{VOEvent Transport Protocol Version 2.0}",
+ howpublished = {IVOA Recommendation 20 March 2017},
+         year = 2017,
+        month = mar,
+        pages = {320},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0320S},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0320S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2017ivoa.spec.0320L,
-   author = {{Languignon}, D. and {Le Petit}, F. and {Rodrigo}, C. and {Lemson}, G. and 
-	{Molinaro}, M. and {Wozniak}, H.},
-    title = "{Simulation Data Access Layer Version 1.0}",
-howpublished = {IVOA Recommendation 20 March 2017},
-     year = 2017,
-    month = mar,
-   editor = {{Languignon}, D. and {Le Petit}, F.},
-      doi = {10.5479/ADS/bib/2017ivoa.spec.0320L},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0320L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Languignon}, David and {Le Petit}, Franck and {Rodrigo}, Carlos and
+         {Lemson}, Gerard and {Molinaro}, Marco and {Wozniak}, Herv{\'e}},
+        title = "{Simulation Data Access Layer Version 1.0}",
+ howpublished = {IVOA Recommendation 20 March 2017},
+         year = 2017,
+        month = mar,
+        pages = {320},
+          doi = {10.5479/ADS/bib/2017ivoa.spec.0320L},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017ivoa.spec.0320L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2016ivoa.spec.1024H,
-   author = {{Harrison}, P.~A. and {Rixon}, G.},
-    title = "{Universal Worker Service Pattern Version 1.1}",
-howpublished = {IVOA Recommendation 24 October 2016},
-     year = 2016,
-    month = oct,
-   editor = {{Harrison}, P.~A.},
-      doi = {10.5479/ADS/bib/2016ivoa.spec.1024H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2016ivoa.spec.1024H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Harrison}, P.~A. and {Rixon}, G.},
+        title = "{Universal Worker Service Pattern Version 1.1}",
+ howpublished = {IVOA Recommendation 24 October 2016},
+         year = 2016,
+        month = oct,
+        pages = {1024},
+          doi = {10.5479/ADS/bib/2016ivoa.spec.1024H},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016ivoa.spec.1024H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2016ivoa.spec.0523D,
-   author = {{Demleitner}, M. and {Plante}, R. and {Linde}, T. and {Williams}, R. and 
-	{Noddle}, K.},
-    title = "{IVOA Identifiers Version 2.0}",
-howpublished = {IVOA Recommendation 23 May 2016},
-     year = 2016,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1605.07501},
- primaryClass = "astro-ph.IM",
-   editor = {{Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2016ivoa.spec.0523D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2016ivoa.spec.0523D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, Markus and {Plante}, Raymond and {Linde}, Tony and
+         {Williams}, Roy and {Noddle}, Keith},
+        title = "{IVOA Identifiers Version 2.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 23 May 2016},
+         year = 2016,
+        month = may,
+        pages = {523},
+          doi = {10.5479/ADS/bib/2016ivoa.spec.0523D},
+archivePrefix = {arXiv},
+       eprint = {1605.07501},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2016ivoa.spec.0523D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2015ivoa.spec.1223D,
-   author = {{Dowler}, P. and {Bonnarel}, F. and {Tody}, D.},
-    title = "{IVOA Simple Image Access Version 2.0}",
-howpublished = {IVOA Recommendation 23 December 2015},
-     year = 2015,
-    month = dec,
-   editor = {{Dowler}, P. and {Bonnarel}, F.},
-      doi = {10.5479/ADS/bib/2015ivoa.spec.1223D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2015ivoa.spec.1223D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Dowler}, Patrick and {Bonnarel}, Fran{\c{c}}ois and {Tody}, Doug},
+        title = "{IVOA Simple Image Access Version 2.0}",
+ howpublished = {IVOA Recommendation 23 December 2015},
+         year = 2015,
+        month = dec,
+        pages = {1223},
+          doi = {10.5479/ADS/bib/2015ivoa.spec.1223D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015ivoa.spec.1223D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2015ivoa.spec.0617D,
-   author = {{Dowler}, P. and {Bonnarel}, F. and {Michel}, L. and {Demleitner}, M.
-	},
-    title = "{IVOA DataLink Version 1.0}",
-howpublished = {IVOA Recommendation 17 June 2015},
-     year = 2015,
-    month = jun,
-archivePrefix = "arXiv",
-   eprint = {1509.06152},
- primaryClass = "astro-ph.IM",
-   editor = {{Dowler}, P.},
-      doi = {10.5479/ADS/bib/2015ivoa.spec.0617D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2015ivoa.spec.0617D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Dowler}, Patrick and {Bonnarel}, Fran{\c{c}}ois and {Michel}, Laurent and
+         {Demleitner}, Markus},
+        title = "{IVOA DataLink Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 17 June 2015},
+         year = 2015,
+        month = jun,
+        pages = {617},
+          doi = {10.5479/ADS/bib/2015ivoa.spec.0617D},
+archivePrefix = {arXiv},
+       eprint = {1509.06152},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2015ivoa.spec.0617D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2014ivoa.spec.1208D,
-   author = {{Demleitner}, M. and {Harrison}, P. and {Molinaro}, M. and {Greene}, G. and 
-	{Dower}, T. and {Perdikeas}, M.},
-    title = "{IVOA Registry Relational Schema Version 1.0}",
-howpublished = {IVOA Recommendation 08 December 2014},
-     year = 2014,
-    month = dec,
-archivePrefix = "arXiv",
-   eprint = {1510.02275},
- primaryClass = "astro-ph.IM",
-   editor = {{Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2014ivoa.spec.1208D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.1208D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, Markus and {Harrison}, Paul and {Molinaro}, Marco and
+         {Greene}, Gretchen and {Dower}, Theresa and {Perdikeas}, Menelaos},
+        title = "{IVOA Registry Relational Schema Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 08 December 2014},
+         year = 2014,
+        month = dec,
+        pages = {1208},
+          doi = {10.5479/ADS/bib/2014ivoa.spec.1208D},
+archivePrefix = {arXiv},
+       eprint = {1510.02275},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.1208D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2014ivoa.spec.0602F,
-   author = {{Fernique}, P. and {Boch}, T. and {Donaldson}, T. and {Durand}, D. and 
-	{O'Mullane}, W. and {Reinecke}, M. and {Taylor}, M.},
-    title = "{MOC - HEALPix Multi-Order Coverage map Version 1.0}",
-howpublished = {IVOA Recommendation 02 June 2014},
-     year = 2014,
-    month = jun,
-archivePrefix = "arXiv",
-   eprint = {1505.02937},
- primaryClass = "astro-ph.IM",
-   editor = {{Fernique}, P.},
-      doi = {10.5479/ADS/bib/2014ivoa.spec.0602F},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.0602F},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Fernique}, Pierre and {Boch}, Thomas and {Donaldson}, Tom and {Durand
+        }, Daniel and {O'Mullane}, Wil and {Reinecke}, Martin and {Taylor}, Mark},
+        title = "{MOC - HEALPix Multi-Order Coverage map Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 02 June 2014},
+         year = 2014,
+        month = jun,
+        pages = {602},
+          doi = {10.5479/ADS/bib/2014ivoa.spec.0602F},
+archivePrefix = {arXiv},
+       eprint = {1505.02937},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.0602F},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2014ivoa.spec.0523Z,
-   author = {{Zwolf}, C.~M. and {Harrison}, P. and {Garrido}, J. and {Ruiz}, J.~E. and 
-	{Le Petit}, F.},
-    title = "{Parameter Description Language Version 1.0}",
-howpublished = {IVOA Recommendation 23 May 2014},
-     year = 2014,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1509.08303},
- primaryClass = "astro-ph.IM",
-   editor = {{Zwolf}, C.~M.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.0523Z},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Zwolf}, Carlo Maria and {Harrison}, Paul and {Garrido}, Julian and
+         {Ruiz}, Jose Enrique and {Le Petit}, Franck},
+        title = "{Parameter Description Language Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Software Engineering},
+ howpublished = {IVOA Recommendation 23 May 2014},
+         year = 2014,
+        month = may,
+        pages = {523},
+          doi = {10.5479/ADS/bib/2014ivoa.spec.0523Z},
+archivePrefix = {arXiv},
+       eprint = {1509.08303},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.0523Z},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2014ivoa.spec.0523D,
-   author = {{Derriere}, S. and {Gray}, N. and {Demleitner}, M. and {Louys}, M. and 
-	{Ochsenbein}, F.},
-    title = "{Units in the VO Version 1.0}",
-howpublished = {IVOA Recommendation 23 May 2014},
-     year = 2014,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1509.07267},
- primaryClass = "astro-ph.IM",
-   editor = {{Derriere}, S. and {Gray}, N.},
-      doi = {10.5479/ADS/bib/2014ivoa.spec.0523D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.0523D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Derriere}, Sebastien and {Gray}, Norman and {Demleitner}, Markus and
+         {Louys}, Mireille and {Ochsenbein}, Francois},
+        title = "{Units in the VO Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 23 May 2014},
+         year = 2014,
+        month = may,
+        pages = {523},
+          doi = {10.5479/ADS/bib/2014ivoa.spec.0523D},
+archivePrefix = {arXiv},
+       eprint = {1509.07267},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2014ivoa.spec.0523D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2013ivoa.rept.1213D,
-   author = {{Demleitner}, M. and {Harrison}, P. and {Taylor}, M.},
-    title = "{TAP Implementation Notes Version 1.0}",
-howpublished = {IVOA Note 13 December 2013},
-     year = 2013,
-    month = dec,
-   editor = {{Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2013ivoa.rept.1213D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.rept.1213D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, Markus and {Harrison}, Paul and {Taylor}, Mark},
+        title = "{TAP Implementation Notes Version 1.0}",
+ howpublished = {IVOA Note 13 December 2013},
+         year = 2013,
+        month = dec,
+        pages = {1213},
+          doi = {10.5479/ADS/bib/2013ivoa.rept.1213D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.rept.1213D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2013ivoa.spec.1129D,
-   author = {{Dowler}, P. and {Demleitner}, M. and {Taylor}, M. and {Tody}, D.
-	},
-    title = "{Data Access Layer Interface Version 1.0}",
-howpublished = {IVOA Recommendation 29 November 2013},
-     year = 2013,
-    month = nov,
-archivePrefix = "arXiv",
-   eprint = {1402.4750},
- primaryClass = "astro-ph.IM",
-   editor = {{Dowler}, P.},
-      doi = {10.5479/ADS/bib/2013ivoa.spec.1129D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.1129D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Dowler}, Patrick and {Demleitner}, Markus and {Taylor}, Mark and
+         {Tody}, Doug},
+        title = "{Data Access Layer Interface Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Software Engineering},
+ howpublished = {IVOA Recommendation 29 November 2013},
+         year = 2013,
+        month = nov,
+        pages = {1129},
+          doi = {10.5479/ADS/bib/2013ivoa.spec.1129D},
+archivePrefix = {arXiv},
+       eprint = {1402.4750},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.1129D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2013ivoa.spec.1125P,
-   author = {{Plante}, R. and {Delago}, J. and {Harrison}, P. and {Tody}, D. and 
-	{IVOA Registry Working Group}},
-    title = "{Describing Simple Data Access Services Version 1.0}",
-howpublished = {IVOA Recommendation 25 November 2013},
-     year = 2013,
-    month = nov,
-archivePrefix = "arXiv",
-   eprint = {1402.4747},
- primaryClass = "astro-ph.IM",
-   editor = {{Plante}, R.},
-      doi = {10.5479/ADS/bib/2013ivoa.spec.1125P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.1125P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {Delago}, Jesus and {Harrison}, Paul and
+         {Tody}, Doug and {IVOA Registry Working Group}},
+        title = "{Describing Simple Data Access Services Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 25 November 2013},
+         year = 2013,
+        month = nov,
+        pages = {1125},
+          doi = {10.5479/ADS/bib/2013ivoa.spec.1125P},
+archivePrefix = {arXiv},
+       eprint = {1402.4747},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.1125P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2013ivoa.spec.1005S,
-   author = {{Salgado}, J. and {Osuna}, P. and {Rodrigo}, C. and {Allen}, M. and 
-	{Louys}, M. and {McDowell}, J. and {Baines}, D. and {Maiz Apellaniz}, J. and 
-	{Hatziminaoglou}, E. and {Derriere}, S. and {Lemson}, G.},
-    title = "{IVOA Photometry Data Model Version 1.0}",
-howpublished = {IVOA Recommendation 05 October 2013},
-     year = 2013,
-    month = oct,
-archivePrefix = "arXiv",
-   eprint = {1402.4752},
- primaryClass = "astro-ph.IM",
-   editor = {{Salgado}, J. and {Osuna}, P.},
-      doi = {10.5479/ADS/bib/2013ivoa.spec.1005S},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.1005S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Salgado}, Jesus and {Osuna}, Pedro and {Rodrigo}, Carlos and
+         {Allen}, Mark and {Louys}, Mireille and {McDowell}, Jonathan and
+         {Baines}, Deborah and {Maiz Apellaniz}, Jesus and
+         {Hatziminaoglou}, Evanthia and {Derriere}, Sebastien and
+         {Lemson}, Gerard},
+        title = "{IVOA Photometry Data Model Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 05 October 2013},
+         year = 2013,
+        month = oct,
+        pages = {1005},
+          doi = {10.5479/ADS/bib/2013ivoa.spec.1005S},
+archivePrefix = {arXiv},
+       eprint = {1402.4752},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.1005S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2013ivoa.spec.0920O,
-   author = {{Ochsenbein}, F. and {Taylor}, M. and {Williams}, R. and {Davenhall}, C. and 
-	{Demleitner}, M. and {Durand}, D. and {Fernique}, P. and {Giaretta}, D. and 
-	{Hanisch}, R. and {McGlynn}, T. and {Szalay}, A. and {Wicenec}, A.
-	},
-    title = "{VOTable Format Definition Version 1.3}",
-howpublished = {IVOA Recommendation 20 September 2013},
-     year = 2013,
-    month = sep,
-   editor = {{Ochsenbein}, F. and {Taylor}, M.},
-      doi = {10.5479/ADS/bib/2013ivoa.spec.0920O},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.0920O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Ochsenbein}, Francois and {Taylor}, Mark and {Williams}, Roy and
+         {Davenhall}, Clive and {Demleitner}, Markus and {Durand}, Daniel and
+         {Fernique}, Pierre and {Giaretta}, David and {Hanisch}, Robert and
+         {McGlynn}, Tom and {Szalay}, Alex and {Wicenec}, Andreas},
+        title = "{VOTable Format Definition Version 1.3}",
+ howpublished = {IVOA Recommendation 20 September 2013},
+         year = 2013,
+        month = sep,
+        pages = {920},
+          doi = {10.5479/ADS/bib/2013ivoa.spec.0920O},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.0920O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2013ivoa.spec.0329G,
-   author = {{Graham}, M. and {Morris}, D. and {Rixon}, G. and {Dowler}, P. and 
-	{Schaaff}, A. and {Tody}, D.},
-    title = "{VOSpace specification Version 2.0}",
-howpublished = {IVOA Recommendation 29 March 2013},
-     year = 2013,
-    month = mar,
-archivePrefix = "arXiv",
-   eprint = {1509.06049},
- primaryClass = "astro-ph.IM",
-   editor = {{Graham}, M.},
-      doi = {10.5479/ADS/bib/2013ivoa.spec.0329G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.0329G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Morris}, Dave and {Rixon}, Guy and {Dowler}, Pat and
+         {Schaaff}, Andre and {Tody}, Doug},
+        title = "{VOSpace specification Version 2.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 29 March 2013},
+         year = 2013,
+        month = mar,
+        pages = {329},
+          doi = {10.5479/ADS/bib/2013ivoa.spec.0329G},
+archivePrefix = {arXiv},
+       eprint = {1509.06049},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2013ivoa.spec.0329G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.rept.1015R,
-   author = {{Rodrigo}, C. and {Solano}, E. and {Bayo}, A.},
-    title = "{SVO Filter Profile Service Version 1.0}",
-howpublished = {IVOA Working Draft 15 October 2012},
-     year = 2012,
-    month = oct,
-   editor = {{Rodrigo}, C.},
-      doi = {10.5479/ADS/bib/2012ivoa.rept.1015R},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.1015R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Rodrigo}, Carlos and {Solano}, Enrique and {Bayo}, Amelia},
+        title = "{SVO Filter Profile Service Version 1.0}",
+ howpublished = {IVOA Working Draft 15 October 2012},
+         year = 2012,
+        month = oct,
+        pages = {1015},
+          doi = {10.5479/ADS/bib/2012ivoa.rept.1015R},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.1015R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.spec.0827D,
-   author = {{Demleitner}, M. and {Dowler}, P. and {Plante}, R. and {Rixon}, G. and 
-	{Taylor}, M.},
-    title = "{TAPRegExt: a VOResource Schema Extension for Describing TAP Services Version 1.0}",
-howpublished = {IVOA Recommendation 27 August 2012},
-     year = 2012,
-    month = aug,
-archivePrefix = "arXiv",
-   eprint = {1402.4742},
- primaryClass = "astro-ph.IM",
-   editor = {{Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2012ivoa.spec.0827D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0827D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, Markus and {Dowler}, Patrick and {Plante}, Ray and
+         {Rixon}, Guy and {Taylor}, Mark},
+        title = "{TAPRegExt: a VOResource Schema Extension for Describing TAP Services Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Databases},
+ howpublished = {IVOA Recommendation 27 August 2012},
+         year = 2012,
+        month = aug,
+        pages = {827},
+          doi = {10.5479/ADS/bib/2012ivoa.spec.0827D},
+archivePrefix = {arXiv},
+       eprint = {1402.4742},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0827D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.spec.0508H,
-   author = {{Harrison}, P. and {Burke}, D. and {Plante}, R. and {Rixon}, G. and 
-	{Morris}, D. and {IVOA Registry Working Group}},
-    title = "{StandardsRegExt: a VOResource Schema Extension for Describing IVOA Standards Version 1.0}",
-howpublished = {IVOA Recommendation 08 May 2012},
-     year = 2012,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1402.4745},
- primaryClass = "astro-ph.IM",
-   editor = {{Harrison}, P.},
-      doi = {10.5479/ADS/bib/2012ivoa.spec.0508H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0508H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Harrison}, Paul and {Burke}, Douglas and {Plante}, Ray and
+         {Rixon}, Guy and {Morris}, Dave and {IVOA Registry Working Group}},
+        title = "{StandardsRegExt: a VOResource Schema Extension for Describing IVOA Standards Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 08 May 2012},
+         year = 2012,
+        month = may,
+        pages = {508},
+          doi = {10.5479/ADS/bib/2012ivoa.spec.0508H},
+archivePrefix = {arXiv},
+       eprint = {1402.4745},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0508H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.spec.0503L,
-   author = {{Lemson}, G. and {Wozniak}, H. and {Bourges}, L. and {Cervino}, M. and 
-	{Gheller}, C. and {Gray}, N. and {LePetit}, F. and {Louys}, M. and 
-	{Ooghe}, B. and {Wagner}, R.},
-    title = "{Simulation Data Model Version 1.0}",
-howpublished = {IVOA Recommendation 03 May 2012},
-     year = 2012,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1402.4744},
- primaryClass = "astro-ph.IM",
-   editor = {{Lemson}, G. and {Wozniak}, H.},
-      doi = {10.5479/ADS/bib/2012ivoa.spec.0503L},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0503L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Lemson}, Gerard and {Wozniak}, Herve and {Bourges}, Laurent and
+         {Cervino}, Miguel and {Gheller}, Claudio and {Gray}, Norman and
+         {LePetit}, Franck and {Louys}, Mireille and {Ooghe}, Benjamin and
+         {Wagner}, Rick},
+        title = "{Simulation Data Model Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 03 May 2012},
+         year = 2012,
+        month = may,
+        pages = {503},
+          doi = {10.5479/ADS/bib/2012ivoa.spec.0503L},
+archivePrefix = {arXiv},
+       eprint = {1402.4744},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0503L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.spec.1104T,
-   author = {{Taylor}, M. and {Boch}, T. and {Fitzpatrick}, M. and {Allan}, A. and 
-	{Fay}, J. and {Paioro}, L. and {Taylor}, J. and {Tody}, D.},
-    title = "{Simple Application Messaging Protocol Version 1.3}",
-howpublished = {IVOA Recommendation 11 April 2012},
-     year = 2012,
-    month = apr,
-   editor = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.1104T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Taylor}, M. and {Boch}, T. and {Fitzpatrick}, M. and {Allan}, A. and
+         {Fay}, J. and {Paioro}, L. and {Taylor}, J. and {Tody}, D.},
+        title = "{Simple Application Messaging Protocol Version 1.3}",
+ howpublished = {IVOA Recommendation 11 April 2012},
+         year = 2012,
+        month = apr,
+        pages = {1104},
+          doi = {10.5479/ADS/bib/2012ivoa.spec.1104T},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.1104T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.spec.0411B,
-   author = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M. and {Allan}, A. and 
-	{Fay}, J. and {Paioro}, L. and {Taylor}, J. and {Tody}, D.},
-    title = "{Simple Application Messaging Protocol Version 1.3}",
-howpublished = {IVOA Recommendation 11 April 2012},
-     year = 2012,
-    month = apr,
-archivePrefix = "arXiv",
-   eprint = {1110.0528},
- primaryClass = "astro-ph.IM",
-   editor = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M.},
-      doi = {10.5479/ADS/bib/2012ivoa.spec.0411B},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0411B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M. and {Allan}, A. and
+         {Fay}, J. and {Paioro}, L. and {Taylor}, J. and {Tody}, D.},
+        title = "{Simple Application Messaging Protocol Version 1.3}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 11 April 2012},
+         year = 2012,
+        month = apr,
+        pages = {411},
+          doi = {10.5479/ADS/bib/2012ivoa.spec.0411B},
+archivePrefix = {arXiv},
+       eprint = {1110.0528},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0411B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.spec.0210T,
-   author = {{Tody}, D. and {Dolensky}, M. and {McDowell}, J. and {Bonnarel}, F. and 
-	{Budavari}, T. and {Busko}, I. and {Micol}, A. and {Osuna}, P. and 
-	{Salgado}, J. and {Skoda}, P. and {Thompson}, R. and {Valdes}, F. and 
-	{Data Access Layer Working Group}},
-    title = "{Simple Spectral Access Protocol Version 1.1}",
-howpublished = {IVOA Recommendation 10 February 2012},
-     year = 2012,
-    month = feb,
-archivePrefix = "arXiv",
-   eprint = {1203.5725},
- primaryClass = "astro-ph.IM",
-   editor = {{Tody}, D.},
-      doi = {10.5479/ADS/bib/2012ivoa.spec.0210T},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0210T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Tody}, Doug and {Dolensky}, Markus and {McDowell}, Jonathan and
+         {Bonnarel}, Francois and {Budavari}, Tamas and {Busko}, Ivo and
+         {Micol}, Alberto and {Osuna}, Pedro and {Salgado}, Jesus and
+         {Skoda}, Petr and {Thompson}, Randy and {Valdes}, Frank and
+         {Data Access Layer Working Group}},
+        title = "{Simple Spectral Access Protocol Version 1.1}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 10 February 2012},
+         year = 2012,
+        month = feb,
+        pages = {210},
+          doi = {10.5479/ADS/bib/2012ivoa.spec.0210T},
+archivePrefix = {arXiv},
+       eprint = {1203.5725},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.spec.0210T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2012ivoa.rept.0126A,
-   author = {{Arviset}, C. and {IVOA Technical Coordination Group}},
-    title = "{The IVOA in 2011: Technical Assessment, Roadmap for 2012 Version 1.0}",
-howpublished = {IVOA Note 26 January 2012},
-     year = 2012,
-    month = jan,
-   editor = {{Arviset}, C.},
-      doi = {10.5479/ADS/bib/2012ivoa.rept.0126A},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.0126A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Arviset}, Christophe and {IVOA Technical Coordination Group}},
+        title = "{The IVOA in 2011: Technical Assessment, Roadmap for 2012 Version 1.0}",
+ howpublished = {IVOA Note 26 January 2012},
+         year = 2012,
+        month = jan,
+        pages = {126},
+          doi = {10.5479/ADS/bib/2012ivoa.rept.0126A},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.0126A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2011ivoa.spec.1120M,
-   author = {{McDowell}, J. and {Tody}, D. and {Budavari}, T. and {Dolensky}, M. and 
-	{Kamp}, I. and {McCusker}, K. and {Protopapas}, P. and {Rots}, A. and 
-	{Thompson}, R. and {Valdes}, F. and {Skoda}, P. and {Rino}, B. and 
-	{Derriere}, S. and {Salgado}, J. and {Laurino}, O. and {IVOA Data Access Layer Group} and 
-	{Data Model Working Group}},
-    title = "{IVOA Spectrum Data Model Version 1.1}",
-howpublished = {IVOA Recommendation 20 November 2011},
-     year = 2011,
-    month = nov,
-archivePrefix = "arXiv",
-   eprint = {1204.3055},
- primaryClass = "astro-ph.IM",
-   editor = {{McDowell}, J. and {Tody}, D.},
-      doi = {10.5479/ADS/bib/2011ivoa.spec.1120M},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.1120M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{McDowell}, Jonathan and {Tody}, Doug and {Budavari}, Tamas and
+         {Dolensky}, Markus and {Kamp}, Inga and {McCusker}, Kelly and
+         {Protopapas}, Pavlos and {Rots}, Arnold and {Thompson}, Randy and
+         {Valdes}, Frank and {Skoda}, Petr and {Rino}, Bruno and
+         {Derriere}, Sebastien and {Salgado}, Jesus and {Laurino}, Omar and
+         {IVOA Data Access Layer Group} and {Data Model Working Group}},
+        title = "{IVOA Spectrum Data Model Version 1.1}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 20 November 2011},
+         year = 2011,
+        month = nov,
+        pages = {1120},
+          doi = {10.5479/ADS/bib/2011ivoa.spec.1120M},
+archivePrefix = {arXiv},
+       eprint = {1204.3055},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.1120M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2011ivoa.spec.1028T,
-   author = {{Tody}, D. and {Micol}, A. and {Durand}, D. and {Louys}, M. and 
-	{Bonnarel}, F. and {Schade}, D. and {Dowler}, P. and {Michel}, L. and 
-	{Salgado}, J. and {Chilingarian}, I. and {Rino}, B. and {de Dios Santander}, J. and 
-	{Skoda}, P.},
-    title = "{Observation Data Model Core Components, its Implementation in the Table Access Protocol Version 1.0}",
-howpublished = {IVOA Recommendation 28 October 2011},
-     year = 2011,
-    month = oct,
-archivePrefix = "arXiv",
-   eprint = {1111.1758},
- primaryClass = "astro-ph.IM",
-   editor = {{Tody}, D. and {Micol}, A. and {Durand}, D. and {Louys}, M.},
-      doi = {10.5479/ADS/bib/2011ivoa.spec.1028T},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.1028T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Tody}, Doug and {Micol}, Alberto and {Durand}, Daniel and
+         {Louys}, Mireille and {Bonnarel}, Francois and {Schade}, David and
+         {Dowler}, Patrick and {Michel}, Laurent and {Salgado}, Jesus and
+         {Chilingarian}, Igor and {Rino}, Bruno and {de Dios Santander}, Juan and
+         {Skoda}, Petr},
+        title = "{Observation Data Model Core Components, its Implementation in the Table Access Protocol Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 28 October 2011},
+         year = 2011,
+        month = oct,
+        pages = {1028},
+          doi = {10.5479/ADS/bib/2011ivoa.spec.1028T},
+archivePrefix = {arXiv},
+       eprint = {1111.1758},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.1028T},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2011ivoa.spec.0711S,
-   author = {{Seaman}, R. and {Williams}, R. and {Allan}, A. and {Barthelmy}, S. and 
-	{Bloom}, J. and {Brewer}, J. and {Denny}, R. and {Fitzpatrick}, M. and 
-	{Graham}, M. and {Gray}, N. and {Hessman}, F. and {Marka}, S. and 
-	{Rots}, A. and {Vestrand}, T. and {Wozniak}, P.},
-    title = "{Sky Event Reporting Metadata Version 2.0}",
-howpublished = {IVOA Recommendation 11 July 2011},
-     year = 2011,
-    month = jul,
-archivePrefix = "arXiv",
-   eprint = {1110.0523},
- primaryClass = "astro-ph.IM",
-   editor = {{Seaman}, R. and {Williams}, R.},
-      doi = {10.5479/ADS/bib/2011ivoa.spec.0711S},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.0711S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Seaman}, Rob and {Williams}, Roy and {Allan}, Alasdair and
+         {Barthelmy}, Scott and {Bloom}, Joshua and {Brewer}, John and
+         {Denny}, Robert and {Fitzpatrick}, Mike and {Graham}, Matthew and
+         {Gray}, Norman and {Hessman}, Frederic and {Marka}, Szabolcs and
+         {Rots}, Arnold and {Vestrand}, Tom and {Wozniak}, Przemyslaw},
+        title = "{Sky Event Reporting Metadata Version 2.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 11 July 2011},
+         year = 2011,
+        month = jul,
+        pages = {711},
+          doi = {10.5479/ADS/bib/2011ivoa.spec.0711S},
+archivePrefix = {arXiv},
+       eprint = {1110.0523},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.0711S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2011ivoa.spec.0531G,
-   author = {{Graham}, M. and {Rixon}, G. and {Grid andWeb Services Working Group}
-	},
-    title = "{IVOA Support Interfaces Version 1.0}",
-howpublished = {IVOA Recommendation 31 May 2011},
-     year = 2011,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1110.5825},
- primaryClass = "astro-ph.IM",
-   editor = {{Graham}, M. and {Rixon}, G.},
-      doi = {10.5479/ADS/bib/2011ivoa.spec.0531G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.0531G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Rixon}, Guy and {Grid and
+        Web Services Working Group}},
+        title = "{IVOA Support Interfaces Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Digital Libraries},
+ howpublished = {IVOA Recommendation 31 May 2011},
+         year = 2011,
+        month = may,
+        pages = {531},
+          doi = {10.5479/ADS/bib/2011ivoa.spec.0531G},
+archivePrefix = {arXiv},
+       eprint = {1110.5825},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011ivoa.spec.0531G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.specQ1209O,
-   author = {{Osuna}, P. and {Salgado}, J. and {Guainazzi}, M. and {Barbarisi}, I. and 
-	{Dubernet}, M.-L. and {Tody}, D.},
-    title = "{Simple Line Access Protocol Version 1.0}",
-howpublished = {IVOA Recommendation 9 December 2010},
-     year = 2010,
-    month = dec,
-archivePrefix = "arXiv",
-   eprint = {1110.0500},
- primaryClass = "astro-ph.IM",
-   editor = {{Osuna}, P. and {Salgado}, J.},
-      doi = {10.5479/ADS/bib/2010ivoa.specQ1209O},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.specQ1209O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Osuna}, Pedro and {Salgado}, Jesus and {Guainazzi}, Matteo and
+         {Barbarisi}, Isa and {Dubernet}, Marie-Lise and {Tody}, Doug},
+        title = "{Simple Line Access Protocol Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 9 December 2010},
+         year = 2010,
+        month = dec,
+        pages = {1209},
+          doi = {10.5479/ADS/bib/2010ivoa.specQ1209O},
+archivePrefix = {arXiv},
+       eprint = {1110.0500},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.specQ1209O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.1216G,
-   author = {{Graham}, M. and {Schaaff}, A.},
-    title = "{Web Services Basic Profile Version 1.0}",
-howpublished = {IVOA Recommendation 16 December 2010},
-     year = 2010,
-    month = dec,
-archivePrefix = "arXiv",
-   eprint = {1110.0511},
- primaryClass = "astro-ph.IM",
-   editor = {{Graham}, M.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1216G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Schaaff}, Andre},
+        title = "{Web Services Basic Profile Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 16 December 2010},
+         year = 2010,
+        month = dec,
+        pages = {1216},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.1216G},
+archivePrefix = {arXiv},
+       eprint = {1110.0511},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1216G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.1216B,
-   author = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M. and {Allan}, A. and 
-	{Paioro}, L. and {Taylor}, J. and {Tody}, D.},
-    title = "{Simple Application Messaging Protocol Version 1.2}",
-howpublished = {IVOA Recommendation 16 December 2010},
-     year = 2010,
-    month = dec,
-   editor = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.1216B},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1216B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M. and {Allan}, A. and
+         {Paioro}, L. and {Taylor}, J. and {Tody}, D.},
+        title = "{Simple Application Messaging Protocol Version 1.2}",
+ howpublished = {IVOA Recommendation 16 December 2010},
+         year = 2010,
+        month = dec,
+        pages = {1216},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.1216B},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1216B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.1209O,
-   author = {{Osuna}, P. and {Salgado}, J. and {Guainazzi}, M. and {Dubernet}, M.-L. and 
-	{Roueff}, E.},
-    title = "{Simple Spectral Lines Data Model Version 1.0}",
-howpublished = {IVOA Recommendation 09 December 2010},
-     year = 2010,
-    month = dec,
-archivePrefix = "arXiv",
-   eprint = {1110.0505},
- primaryClass = "astro-ph.IM",
-   editor = {{Osuna}, P. and {Salgado}, J.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.1209O},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1209O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Osuna}, Pedro and {Salgado}, Jesus and {Guainazzi}, Matteo and
+         {Dubernet}, Marie-Lise and {Roueff}, Evelyne},
+        title = "{Simple Spectral Lines Data Model Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 09 December 2010},
+         year = 2010,
+        month = dec,
+        pages = {1209},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.1209O},
+archivePrefix = {arXiv},
+       eprint = {1110.0505},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1209O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.1202P,
-   author = {{Plante}, R. and {St{\'e}b{\'e}}, A. and {Benson}, K. and {Dowler}, P. and 
-	{Graham}, M. and {Greene}, G. and {Harrison}, P. and {Lemson}, G. and 
-	{Linde}, T. and {Rixon}, G.},
-    title = "{VODataService: a VOResource Schema Extension for Describing Collections, Services Version 1.1}",
-howpublished = {IVOA Recommendation 02 December 2010},
-     year = 2010,
-    month = dec,
-archivePrefix = "arXiv",
-   eprint = {1110.0516},
- primaryClass = "astro-ph.IM",
-   editor = {{Plante}, R.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.1202P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1202P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {St{\'e}b{\'e}}, Aur{\'e}lien and {Benson}, Kevin and
+         {Dowler}, Patrick and {Graham}, Matthew and {Greene}, Gretchen and
+         {Harrison}, Paul and {Lemson}, Gerard and {Linde}, Tony and
+         {Rixon}, Guy},
+        title = "{VODataService: a VOResource Schema Extension for Describing Collections, Services Version 1.1}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 02 December 2010},
+         year = 2010,
+        month = dec,
+        pages = {1202},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.1202P},
+archivePrefix = {arXiv},
+       eprint = {1110.0516},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1202P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.rept.1123A,
-   author = {{Arviset}, C. and {Gaudet}, S. and {IVOA Technical Coordination Group}
-	},
-    title = "{IVOA Architecture Version 1.0}",
-howpublished = {IVOA Note 23 November 2010},
-     year = 2010,
-    month = nov,
-   editor = {{Arviset}, C.},
-      doi = {10.5479/ADS/bib/2010ivoa.rept.1123A},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.1123A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Arviset}, Christophe and {Gaudet}, Severin and
+         {IVOA Technical Coordination Group}},
+        title = "{IVOA Architecture Version 1.0}",
+ howpublished = {IVOA Note 23 November 2010},
+         year = 2010,
+        month = nov,
+        pages = {1123},
+          doi = {10.5479/ADS/bib/2010ivoa.rept.1123A},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.1123A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.1010H,
-   author = {{Harrison}, P. and {Rixon}, G.},
-    title = "{Universal Worker Service Pattern Version 1.0}",
-howpublished = {IVOA Recommendation 10 October 2010},
-     year = 2010,
-    month = oct,
-archivePrefix = "arXiv",
-   eprint = {1110.0510},
- primaryClass = "astro-ph.IM",
-   editor = {{Harrison}, P.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.1010H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1010H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Harrison}, Paul and {Rixon}, Guy},
+        title = "{Universal Worker Service Pattern Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Computer Science - Distributed, Parallel, and Cluster Computing},
+ howpublished = {IVOA Recommendation 10 October 2010},
+         year = 2010,
+        month = oct,
+        pages = {1010},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.1010H},
+archivePrefix = {arXiv},
+       eprint = {1110.0510},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.1010H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.rept.1007A,
-   author = {{Arviset}, C. and {IVOA TCG}},
-    title = "{The IVOA in 2010: Technical Assessment, Roadmap Version 1.0}",
-howpublished = {IVOA Note 07 October 2010},
-     year = 2010,
-    month = oct,
-   editor = {{Arviset}, C.},
-      doi = {10.5479/ADS/bib/2010ivoa.rept.1007A},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.1007A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Arviset}, Christophe and {IVOA TCG}},
+        title = "{The IVOA in 2010: Technical Assessment, Roadmap Version 1.0}",
+ howpublished = {IVOA Note 07 October 2010},
+         year = 2010,
+        month = oct,
+        pages = {1007},
+          doi = {10.5479/ADS/bib/2010ivoa.rept.1007A},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.1007A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.rept.0707H,
-   author = {{Hanisch}, R.~J. and {Quinn}, P.~J. and {De Young}, D. and {Padovani}, P. and 
-	{Pasian}, F.},
-    title = "{Guidelines for Participation Version 1.1}",
-howpublished = {IVOA Note 7 July 2010},
-     year = 2010,
-    month = jul,
-   editor = {{Hanisch}, R.~J.},
-      doi = {10.5479/ADS/bib/2010ivoa.rept.0707H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0707H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Hanisch}, R.~J. and {Quinn}, P.~J. and {De Young}, D. and
+         {Padovani}, P. and {Pasian}, F.},
+        title = "{Guidelines for Participation Version 1.1}",
+ howpublished = {IVOA Note 7 July 2010},
+         year = 2010,
+        month = jul,
+        pages = {707},
+          doi = {10.5479/ADS/bib/2010ivoa.rept.0707H},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0707H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.rept.0618D,
-   author = {{Demleitner}, M. and {Ochsenbein}, F. and {McDowell}, J. and 
-	{Rots}, A.},
-    title = "{Referencing STC in VOTable Version 2.0}",
-howpublished = {IVOA Note 18 June 2010},
-     year = 2010,
-    month = jun,
-   editor = {{Demleitner}, M.},
-      doi = {10.5479/ADS/bib/2010ivoa.rept.0618D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0618D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Demleitner}, M. and {Ochsenbein}, F. and {McDowell}, J. and {Rots}, A.},
+        title = "{Referencing STC in VOTable Version 2.0}",
+ howpublished = {IVOA Note 18 June 2010},
+         year = 2010,
+        month = jun,
+        pages = {618},
+          doi = {10.5479/ADS/bib/2010ivoa.rept.0618D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0618D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.0413H,
-   author = {{Hanisch}, R.~J. and {Arviset}, C. and {Genova}, F. and {Rino}, B.
-	},
-    title = "{IVOA Document Standards Version 1.2}",
-howpublished = {IVOA Recommendation 13 April 2010},
-     year = 2010,
-    month = apr,
-archivePrefix = "arXiv",
-   eprint = {1110.0522},
- primaryClass = "astro-ph.IM",
-   editor = {{Hanisch}, R.~J.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.0413H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.0413H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Hanisch}, R.~J. and {Arviset}, C. and {Genova}, F. and {Rino}, B.},
+        title = "{IVOA Document Standards Version 1.2}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 13 April 2010},
+         year = 2010,
+        month = apr,
+        pages = {413},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.0413H},
+archivePrefix = {arXiv},
+       eprint = {1110.0522},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.0413H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.0327D,
-   author = {{Dowler}, P. and {Rixon}, G. and {Tody}, D.},
-    title = "{Table Access Protocol Version 1.0}",
-howpublished = {IVOA Recommendation 27 March 2010},
-     year = 2010,
-    month = mar,
-archivePrefix = "arXiv",
-   eprint = {1110.0497},
- primaryClass = "astro-ph.IM",
-   editor = {{Dowler}, P.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.0327D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.0327D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Dowler}, Patrick and {Rixon}, Guy and {Tody}, Doug},
+        title = "{Table Access Protocol Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 27 March 2010},
+         year = 2010,
+        month = mar,
+        pages = {327},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.0327D},
+archivePrefix = {arXiv},
+       eprint = {1110.0497},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.0327D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.rept.0303D,
-   author = {{Derriere}, S. and {Preite-Martinez}, A. and {Richard}, A. and 
-	{Cambr{\'e}sy}, L. and {Padovani}, P.},
-    title = "{Ontology of Astronomical Object Types Version 1.3}",
-howpublished = {IVOA Note 03 March 2010},
-     year = 2010,
-    month = mar,
-   editor = {{Derriere}, S. and {Preite-Martinez}, A. and {Richard}, A.},
-      doi = {10.5479/ADS/bib/2010ivoa.rept.0303D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0303D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Derriere}, S{\'e}bastien and {Preite-Martinez}, Andrea and
+         {Richard}, Alexandre and {Cambr{\'e}sy}, Laurent and {Padovani}, Paolo},
+        title = "{Ontology of Astronomical Object Types Version 1.3}",
+ howpublished = {IVOA Note 03 March 2010},
+         year = 2010,
+        month = mar,
+        pages = {303},
+          doi = {10.5479/ADS/bib/2010ivoa.rept.0303D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0303D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.spec.0218P,
-   author = {{Plante}, R. and {Graham}, M. and {Rixon}, G. and {Taffoni}, G.
-	},
-    title = "{IVOA Credential Delegation Protocol Version 1.0}",
-howpublished = {IVOA Recommendation 18 February 2010},
-     year = 2010,
-    month = feb,
-archivePrefix = "arXiv",
-   eprint = {1110.0509},
- primaryClass = "astro-ph.IM",
-   editor = {{Plante}, R. and {Graham}, M.},
-      doi = {10.5479/ADS/bib/2010ivoa.spec.0218P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.0218P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {Graham}, Matthew and {Rixon}, Guy and
+         {Taffoni}, Giuliano},
+        title = "{IVOA Credential Delegation Protocol Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 18 February 2010},
+         year = 2010,
+        month = feb,
+        pages = {218},
+          doi = {10.5479/ADS/bib/2010ivoa.spec.0218P},
+archivePrefix = {arXiv},
+       eprint = {1110.0509},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.spec.0218P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2010ivoa.rept.0117R,
-   author = {{Derriere}, S. and {Preite-Martinez}, A. and {Richard}, A. and 
-	{Cambr{\'e}sy}, L. and {Padovani}, P.},
-    title = "{Ontology of Astronomical Object Types Use Cases Version 1.1}",
-howpublished = {IVOA Note 17 January 2010},
-     year = 2010,
-    month = jan,
-   editor = {{Derriere}, S. and {Preite-Martinez}, A. and {Richard}, A.},
-      doi = {10.5479/ADS/bib/2010ivoa.rept.0117R},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0117R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Derriere}, S. and {Preite-Martinez}, A. and {Richard}, A. and
+         {Cambr{\'e}sy}, L. and {Padovani}, P.},
+        title = "{Ontology of Astronomical Object Types Use Cases Version 1.1}",
+ howpublished = {IVOA Note 17 January 2010},
+         year = 2010,
+        month = jan,
+        pages = {117},
+          doi = {10.5479/ADS/bib/2010ivoa.rept.0117R},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2010ivoa.rept.0117R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.spec.1130O,
-   author = {{Ochsenbein}, F. and {Williams}, R.},
-    title = "{VOTable Format Definition Version 1.2}",
-howpublished = {IVOA Recommendation 30 November 2009},
-     year = 2009,
-    month = nov,
-archivePrefix = "arXiv",
-   eprint = {1110.0524},
- primaryClass = "astro-ph.IM",
-   editor = {{Ochsenbein}, F.},
-      doi = {10.5479/ADS/bib/2009ivoa.spec.1130O},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1130O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Ochsenbein}, Francois and {Williams}, Roy},
+        title = "{VOTable Format Definition Version 1.2}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 30 November 2009},
+         year = 2009,
+        month = nov,
+        pages = {1130},
+          doi = {10.5479/ADS/bib/2009ivoa.spec.1130O},
+archivePrefix = {arXiv},
+       eprint = {1110.0524},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1130O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.spec.1111H,
-   author = {{Harrison}, P. and {Tody}, D. and {Plante}, R.},
-    title = "{Simple Image Access Specification Version 1.0}",
-howpublished = {IVOA Recommendation 11 November 2009},
-     year = 2009,
-    month = nov,
-archivePrefix = "arXiv",
-   eprint = {1110.0499},
- primaryClass = "astro-ph.IM",
-   editor = {{Harrison}, P.},
-      doi = {10.5479/ADS/bib/2009ivoa.spec.1111H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1111H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Harrison}, Paul and {Tody}, Doug and {Plante}, Ray},
+        title = "{Simple Image Access Specification Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 11 November 2009},
+         year = 2009,
+        month = nov,
+        pages = {1111},
+          doi = {10.5479/ADS/bib/2009ivoa.spec.1111H},
+archivePrefix = {arXiv},
+       eprint = {1110.0499},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1111H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.spec.1104B,
-   author = {{Benson}, K. and {Plante}, R. and {Auden}, E. and {Graham}, M. and 
-	{Greene}, G. and {Hill}, M. and {Linde}, T. and {Morris}, D. and 
-	{O`Mullane}, W. and {Rixon}, G. and {St{\'e}b{\'e}}, A. and 
-	{Andrews}, K.},
-    title = "{IVOA Registry Interfaces Version 1.0}",
-howpublished = {IVOA Recommendation 04 November 2009},
-     year = 2009,
-    month = nov,
-archivePrefix = "arXiv",
-   eprint = {1110.0513},
- primaryClass = "astro-ph.IM",
-   editor = {{Benson}, K. and {Plante}, R.},
-      doi = {10.5479/ADS/bib/2009ivoa.spec.1104B},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1104B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Benson}, Kevin and {Plante}, Ray and {Auden}, Elizabeth and
+         {Graham}, Matthew and {Greene}, Gretchen and {Hill}, Martin and
+         {Linde}, Tony and {Morris}, Dave and {O`Mullane}, Wil and {Rixon}, Guy and
+         {St{\'e}b{\'e}}, Aur{\'e}lien and {Andrews}, Kona},
+        title = "{IVOA Registry Interfaces Version 1.0}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 04 November 2009},
+         year = 2009,
+        month = nov,
+        pages = {1104},
+          doi = {10.5479/ADS/bib/2009ivoa.spec.1104B},
+archivePrefix = {arXiv},
+       eprint = {1110.0513},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1104B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.specQ1007G,
-   author = {{Graham}, M. and {Morris}, D. and {Rixon}, G.},
-    title = "{VOSpace specification Version 1.15}",
-howpublished = {IVOA Recommendation 07 October 2009},
-     year = 2009,
-    month = oct,
-   editor = {{Graham}, M.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.specQ1007G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Morris}, Dave and {Rixon}, Guy},
+        title = "{VOSpace specification Version 1.15}",
+ howpublished = {IVOA Recommendation 07 October 2009},
+         year = 2009,
+        month = oct,
+        pages = {1007},
+          doi = {10.5479/ADS/bib/2009ivoa.specQ1007G},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.specQ1007G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.spec.1007G,
-   author = {{Gray}, A.~J.~G. and {Gray}, N. and {Hessman}, F.~V. and {Preite Martinez}, A. and 
-	{Derriere}, S. and {Linde}, T. and {Seaman}, R. and {Thomas}, B.
-	},
-    title = "{Vocabularies in the Virtual Observatory Version 1.19}",
-howpublished = {IVOA Recommendation 07 October 2009},
-     year = 2009,
-    month = oct,
-archivePrefix = "arXiv",
-   eprint = {1110.0520},
- primaryClass = "astro-ph.IM",
-   editor = {{Gray}, A.~J.~G. and {Gray}, N. and {Hessman}, F.~V. and {Preite Martinez}, A. and 
-	{Derriere}, S.},
-      doi = {10.5479/ADS/bib/2009ivoa.spec.1007G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1007G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Gray}, Alasdair J.~G. and {Gray}, Norman and {Hessman}, Frederic V. and
+         {Preite Martinez}, Andrea and {Derriere}, S{\'e}bastien and
+         {Linde}, Tony and {Seaman}, Rob and {Thomas}, Brian},
+        title = "{Vocabularies in the Virtual Observatory Version 1.19}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 07 October 2009},
+         year = 2009,
+        month = oct,
+        pages = {1007},
+          doi = {10.5479/ADS/bib/2009ivoa.spec.1007G},
+archivePrefix = {arXiv},
+       eprint = {1110.0520},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.1007G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.rept.1030R,
-   author = {{Rots}, A.~H.},
-    title = "{STC-S: Space-Time Coordinate (STC) Metadata Linear String Implementation Version 1.33}",
-howpublished = {IVOA Working Draft 30 October 2009},
-     year = 2009,
-    month = oct,
-   editor = {{Rots}, A.~H.},
-      doi = {10.5479/ADS/bib/2009ivoa.rept.1030R},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.rept.1030R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Rots}, A.~H.},
+        title = "{STC-S: Space-Time Coordinate (STC) Metadata Linear String Implementation Version 1.33}",
+ howpublished = {IVOA Working Draft 30 October 2009},
+         year = 2009,
+        month = oct,
+        pages = {1030},
+          doi = {10.5479/ADS/bib/2009ivoa.rept.1030R},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.rept.1030R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.rept.1001A,
-   author = {{Arviset}, C. and {IVOA Technical Coordination Group}},
-    title = "{The IVOA in 2009: Technical Assessment, Roadmap Version 1.0}",
-howpublished = {IVOA Note 01 October 2009},
-     year = 2009,
-    month = oct,
-   editor = {{Arviset}, C.},
-      doi = {10.5479/ADS/bib/2009ivoa.rept.1001A},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.rept.1001A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Arviset}, Christophe and {IVOA Technical Coordination Group}},
+        title = "{The IVOA in 2009: Technical Assessment, Roadmap Version 1.0}",
+ howpublished = {IVOA Note 01 October 2009},
+         year = 2009,
+        month = oct,
+        pages = {1001},
+          doi = {10.5479/ADS/bib/2009ivoa.rept.1001A},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.rept.1001A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.rept.0110I,
-   author = {{IVOA Technical Coordination Group}},
-    title = "{The IVOA in 2009: Technical Assessment and Roadmap Version 1.0}",
-howpublished = {IVOA Note 01 October 2009},
-     year = 2009,
-    month = oct,
-   editor = {{Arviset}, C.},
-      doi = {10.5479/ADS/bib/2009ivoa.rept.0110I},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.rept.0110I},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{IVOA Technical Coordination Group}},
+        title = "{The IVOA in 2009: Technical Assessment and Roadmap Version 1.0}",
+ howpublished = {IVOA Note 01 October 2009},
+         year = 2009,
+        month = oct,
+        pages = {110},
+          doi = {10.5479/ADS/bib/2009ivoa.rept.0110I},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.rept.0110I},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2009ivoa.spec.0421B,
-   author = {{Boch}, T. and {Fitzpatrick}, M. and {Taylor}, M. and {Allan}, A. and 
-	{Paioro}, L. and {Taylor}, J. and {Tody}, D.},
-    title = "{SAMP {\mdash} Simple Application Messaging Protocol Version 1.11}",
-howpublished = {IVOA Recommendation 21 April 2009},
-     year = 2009,
-    month = apr,
-   editor = {{Boch},T. and {Fitzpatrick}, M. and {Taylor}, M.},
-      doi = {10.5479/ADS/bib/2009ivoa.spec.0421B},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.0421B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Boch}, Thomas and {Fitzpatrick}, Michael and {Taylor}, Mark and
+         {Allan}, Alasdair and {Paioro}, Luigi and {Taylor}, John and
+         {Tody}, Douglas},
+        title = "{SAMP {\textemdash} Simple Application Messaging Protocol Version 1.11}",
+ howpublished = {IVOA Recommendation 21 April 2009},
+         year = 2009,
+        month = apr,
+        pages = {421},
+          doi = {10.5479/ADS/bib/2009ivoa.spec.0421B},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2009ivoa.spec.0421B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.spec.1030O,
-   author = {{Osuna}, P. and {Ortiz}, I. and {Lusted}, J. and {Dowler}, P. and 
-	{Szalay}, A. and {Shirasaki}, Y. and {Nieto-Santisteban}, M.~A. and 
-	{Ohishi}, M. and {O'Mullane}, W. and {VOQL-TEG Group} and {VOQL Working Group.}
-	},
-    title = "{IVOA Astronomical Data Query Language Version 2.00}",
-howpublished = {IVOA Recommendation 30 October 2008},
-     year = 2008,
-    month = oct,
-archivePrefix = "arXiv",
-   eprint = {1110.0503},
- primaryClass = "astro-ph.IM",
-   editor = {{Osuna}, P. and {Ortiz}, I.},
-      doi = {10.5479/ADS/bib/2008ivoa.spec.1030O},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.1030O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Osuna}, Pedro and {Ortiz}, I{\~n}aki and {Lusted}, Jeff and
+         {Dowler}, Pat and {Szalay}, Alexander and {Shirasaki}, Yuji and
+         {Nieto-Santisteban}, Maria A. and {Ohishi}, Masatoshi and
+         {O'Mullane}, William and {VOQL-TEG Group} and {VOQL Working Group.}},
+        title = "{IVOA Astronomical Data Query Language Version 2.00}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 30 October 2008},
+         year = 2008,
+        month = oct,
+        pages = {1030},
+          doi = {10.5479/ADS/bib/2008ivoa.spec.1030O},
+archivePrefix = {arXiv},
+       eprint = {1110.0503},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.1030O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.rept.0807A,
-   author = {{Arviset}, C. and {IVOA TCG}},
-    title = "{The IVOA in 2008: Technical Assessment, Roadmap Version 1.00}",
-howpublished = {IVOA Note 07 August 2008},
-     year = 2008,
-    month = aug,
-   editor = {{Arviset}, C.},
-      doi = {10.5479/ADS/bib/2008ivoa.rept.0807A},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.rept.0807A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Arviset}, Christophe and {IVOA TCG}},
+        title = "{The IVOA in 2008: Technical Assessment, Roadmap Version 1.00}",
+ howpublished = {IVOA Note 07 August 2008},
+         year = 2008,
+        month = aug,
+        pages = {807},
+          doi = {10.5479/ADS/bib/2008ivoa.rept.0807A},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.rept.0807A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.spec.0325L,
-   author = {{Louys}, M. and {Richards}, A. and {Bonnarel}, F. and {Micol}, A. and 
-	{Chilingarian}, I. and {McDowell}, J. and {IVOA Data Model Working Group}
-	},
-    title = "{Data Model for Astronomical DataSet Characterisation Version 1.13}",
-howpublished = {IVOA Recommendation 25 March 2008},
-     year = 2008,
-    month = mar,
-archivePrefix = "arXiv",
-   eprint = {1111.2281},
- primaryClass = "astro-ph.IM",
-   editor = {{Louys}, M. and {Richards}, A. and {Bonnarel}, F. and {Micol}, A. and 
-	{Chilingarian}, I. and {McDowell}, J.},
-      doi = {10.5479/ADS/bib/2008ivoa.spec.0325L},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0325L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Louys}, Mireille and {Richards}, Anita and {Bonnarel}, Fran{\c{c}}ois and
+         {Micol}, Alberto and {Chilingarian}, Igor and {McDowell}, Jonathan and
+         {IVOA Data Model Working Group}},
+        title = "{Data Model for Astronomical DataSet Characterisation Version 1.13}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 25 March 2008},
+         year = 2008,
+        month = mar,
+        pages = {325},
+          doi = {10.5479/ADS/bib/2008ivoa.spec.0325L},
+archivePrefix = {arXiv},
+       eprint = {1111.2281},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0325L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.specQ0222P,
-   author = {{Plante}, R. and {Williams}, R. and {Hanisch}, R. and {Szalay}, A.
-	},
-    title = "{Simple Cone Search Version 1.03}",
-howpublished = {IVOA Recommendation 22 February 2008},
-     year = 2008,
-    month = feb,
-archivePrefix = "arXiv",
-   eprint = {1110.0498},
- primaryClass = "astro-ph.IM",
-   editor = {{Plante}, R.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.specQ0222P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {Williams}, Roy and {Hanisch}, Robert and
+         {Szalay}, Alex},
+        title = "{Simple Cone Search Version 1.03}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 22 February 2008},
+         year = 2008,
+        month = feb,
+        pages = {222},
+          doi = {10.5479/ADS/bib/2008ivoa.specQ0222P},
+archivePrefix = {arXiv},
+       eprint = {1110.0498},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.specQ0222P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.spec.0222P,
-   author = {{Plante}, R. and {Benson}, K. and {Graham}, M. and {Greene}, G. and 
-	{Harrison}, P. and {Lemson}, G. and {Linde}, T. and {Rixon}, G. and 
-	{St{\'e}b{\'e}}, A. and {IVOA Registry Working Group}},
-    title = "{VOResource: an XML Encoding Schema for Resource Metadata Version 1.03}",
-howpublished = {IVOA Recommendation 22 February 2008},
-     year = 2008,
-    month = feb,
-archivePrefix = "arXiv",
-   eprint = {1110.0515},
- primaryClass = "astro-ph.IM",
-   editor = {{Plante}, R.},
-      doi = {10.5479/ADS/bib/2008ivoa.spec.0222P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0222P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {Benson}, Kevin and {Graham}, Matthew and
+         {Greene}, Gretchen and {Harrison}, Paul and {Lemson}, Gerard and
+         {Linde}, Tony and {Rixon}, Guy and {St{\'e}b{\'e}}, Aur{\'e}lien and
+         {IVOA Registry Working Group}},
+        title = "{VOResource: an XML Encoding Schema for Resource Metadata Version 1.03}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 22 February 2008},
+         year = 2008,
+        month = feb,
+        pages = {222},
+          doi = {10.5479/ADS/bib/2008ivoa.spec.0222P},
+archivePrefix = {arXiv},
+       eprint = {1110.0515},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0222P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.spec.0201D,
-   author = {{Tody}, D. and {Dolensky}, M. and {McDowell}, J. and {Bonnarel}, F. and 
-	{Budavari}, T. and {Busko}, I. and {Micol}, A. and {Osuna}, P. and 
-	{Salgado}, J. and {Skoda}, P. and {Thompson}, R. and {Valdes}, F. and 
-	{Data Access Layer Working Group}},
-    title = "{Simple Spectral Access Protocol Version 1.04}",
-howpublished = {IVOA Recommendation 01 February 2008},
-     year = 2008,
-    month = feb,
-   editor = {{Tody}, D. and {Dolensky}, M.},
-      doi = {10.5479/ADS/bib/2008ivoa.spec.0201D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0201D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Tody}, D. and {Dolensky}, M. and {McDowell}, J. and {Bonnarel}, F. and
+         {Budavari}, T. and {Busko}, I. and {Micol}, A. and {Osuna}, P. and
+         {Salgado}, J. and {Skoda}, P. and {Thompson}, R. and {Valdes}, F. and
+         {Data Access Layer Working Group}},
+        title = "{Simple Spectral Access Protocol Version 1.04}",
+ howpublished = {IVOA Recommendation 01 February 2008},
+         year = 2008,
+        month = feb,
+        pages = {201},
+          doi = {10.5479/ADS/bib/2008ivoa.spec.0201D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0201D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.spec.0124R,
-   author = {{Rixon}, G. and {Graham}, M. and {Grid andWeb Services Working Group}
-	},
-    title = "{IVOA Single-Sign-On Profile: Authentication Mechanisms Version 1.01}",
-howpublished = {IVOA Recommendation 24 January 2008},
-     year = 2008,
-    month = jan,
-archivePrefix = "arXiv",
-   eprint = {1110.0506},
- primaryClass = "astro-ph.IM",
-   editor = {{Rixon}, G. and {Graham}, M.},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0124R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Rixon}, Guy and {Graham}, Matthew and {Grid and
+        Web Services Working Group}},
+        title = "{IVOA Single-Sign-On Profile: Authentication Mechanisms Version 1.01}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 24 January 2008},
+         year = 2008,
+        month = jan,
+        pages = {124},
+          doi = {10.5479/ADS/bib/2008ivoa.spec.0124R},
+archivePrefix = {arXiv},
+       eprint = {1110.0506},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0124R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2008ivoa.spec.0124G,
-   author = {{Graham}, M. and {Harrison}, P. and {Morris}, D. and {Rixon}, G.
-	},
-    title = "{VOSpace service specification Version 1.02}",
-howpublished = {IVOA Recommendation 24 January 2008},
-     year = 2008,
-    month = jan,
-   editor = {{Graham}, M.},
-      doi = {10.5479/ADS/bib/2008ivoa.spec.0124G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0124G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Graham}, Matthew and {Harrison}, Paul and {Morris}, Dave and
+         {Rixon}, Guy},
+        title = "{VOSpace service specification Version 1.02}",
+ howpublished = {IVOA Recommendation 24 January 2008},
+         year = 2008,
+        month = jan,
+        pages = {124},
+          doi = {10.5479/ADS/bib/2008ivoa.spec.0124G},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2008ivoa.spec.0124G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.1220D,
-   author = {{Tody}, D. and {Dolensky}, M. and {McDowell}, J. and {Bonnarel}, F. and 
-	{Budavari}, T. and {Busko}, I. and {Micol}, A. and {Osuna}, P. and 
-	{Salgado}, J. and {Skoda}, P. and {Thompson}, R. and {Valdes}, F. and 
-	{Data Access Layer Working Group}},
-    title = "{Simple Spectral Access Protocol Version 1.03}",
-howpublished = {IVOA Recommendation 20 December 2007},
-     year = 2007,
-    month = dec,
-   editor = {{Tody}, D. and {Dolensky}, M.},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.1220D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1220D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Tody}, D. and {Dolensky}, M. and {McDowell}, J. and {Bonnarel}, F. and
+         {Budavari}, T. and {Busko}, I. and {Micol}, A. and {Osuna}, P. and
+         {Salgado}, J. and {Skoda}, P. and {Thompson}, R. and {Valdes}, F. and
+         {Data Access Layer Working Group}},
+        title = "{Simple Spectral Access Protocol Version 1.03}",
+ howpublished = {IVOA Recommendation 20 December 2007},
+         year = 2007,
+        month = dec,
+        pages = {1220},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.1220D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1220D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.1108L,
-   author = {{Louys}, M. and {Richards}, A. and {Bonnarel}, F. and {Micol}, A. and 
-	{Chilingarian}, I. and {McDowell}, J. and {IVOA Data Model Working Group}
-	},
-    title = "{Data Model for Astronomical DataSet Characterisation Version 1.12}",
-howpublished = {IVOA Recommendation 08 November 2007},
-     year = 2007,
-    month = nov,
-   editor = {{Louys}, M. and {Richards}, A. and {Bonnarel}, F. and {Micol}, A. and 
-	{Chilingarian}, I. and {McDowell}, J.},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.1108L},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1108L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Louys}, Mireille and {Richards}, Anita and {Bonnarel}, Fran{\c{c}}ois and
+         {Micol}, Alberto and {Chilingarian}, Igor and {McDowell}, Jonathan and
+         {IVOA Data Model Working Group}},
+        title = "{Data Model for Astronomical DataSet Characterisation Version 1.12}",
+ howpublished = {IVOA Recommendation 08 November 2007},
+         year = 2007,
+        month = nov,
+        pages = {1108},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.1108L},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1108L},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.1030R,
-   author = {{Rots}, A.~H.},
-    title = "{Space-Time Coordinate Metadata for the Virtual Observatory Version 1.33}",
-howpublished = {IVOA Recommendation 30 October 2007},
-     year = 2007,
-    month = oct,
-archivePrefix = "arXiv",
-   eprint = {1110.0504},
- primaryClass = "astro-ph.IM",
-   editor = {{Rots}, A.~H.},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.1030R},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1030R},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Rots}, A.~H.},
+        title = "{Space-Time Coordinate Metadata for the Virtual Observatory Version 1.33}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 30 October 2007},
+         year = 2007,
+        month = oct,
+        pages = {1030},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.1030R},
+archivePrefix = {arXiv},
+       eprint = {1110.0504},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1030R},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.1029M,
-   author = {{McDowell}, J. and {Tody}, D. and {Budavari}, T. and {Dolensky}, M. and 
-	{Kamp}, I. and {McCusker}, K. and {Protopapas}, P. and {Rots}, A. and 
-	{Thompson}, R. and {Valdes}, F. and {Skoda}, P. and {IVOA Data Access Layer} and 
-	{Data Model Working Groups}},
-    title = "{IVOA Spectral Data Model Version 1.03}",
-howpublished = {IVOA Recommendation 29 October 2007},
-     year = 2007,
-    month = oct,
-   editor = {{McDowell}, J. and {Tody}, D. and {Budavari}, T. and {Dolensky}, M. and 
-	{Kamp}, I. and {McCusker}, K. and {Protopapas}, P. and {Rots}, A. and 
-	{Thompson}, R. and {Valdes}, F. and {Skoda}, P. and {IVOA Data Access Layer} and 
-	{Data Model Working Groups}},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.1029M},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1029M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{McDowell}, Jonathan and {Tody}, Doug and {Budavari}, Tamas and
+         {Dolensky}, Markus and {Kamp}, Inga and {McCusker}, Kelly and
+         {Protopapas}, Pavlos and {Rots}, Arnold and {Thompson}, Randy and
+         {Valdes}, Frank and {Skoda}, Petr and {IVOA Data Access Layer} and
+         {Data Model Working Groups} and {Data Model Working Groups}},
+        title = "{IVOA Spectral Data Model Version 1.03}",
+ howpublished = {IVOA Recommendation 29 October 2007},
+         year = 2007,
+        month = oct,
+        pages = {1029},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.1029M},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.1029M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.rept.0920G,
-   author = {{Gray}, N.},
-    title = "{An RDF version of the VO Registry Version 1.00}",
-howpublished = {IVOA Note 20 September 2007},
-     year = 2007,
-    month = sep,
-   editor = {{Gray}, N.},
-      doi = {10.5479/ADS/bib/2007ivoa.rept.0920G},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0920G},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Gray}, Norman},
+        title = "{An RDF version of the VO Registry Version 1.00}",
+ howpublished = {IVOA Note 20 September 2007},
+         year = 2007,
+        month = sep,
+        pages = {920},
+          doi = {10.5479/ADS/bib/2007ivoa.rept.0920G},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0920G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.rept.0628P,
-   author = {{Plante}, R.},
-    title = "{The Registry of Registries Version 1.00}",
-howpublished = {IVOA Note 28 June 2007},
-     year = 2007,
-    month = jun,
-   editor = {{Plante}, R.},
-      doi = {10.5479/ADS/bib/2007ivoa.rept.0628P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0628P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond},
+        title = "{The Registry of Registries Version 1.00}",
+ howpublished = {IVOA Note 28 June 2007},
+         year = 2007,
+        month = jun,
+        pages = {628},
+          doi = {10.5479/ADS/bib/2007ivoa.rept.0628P},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0628P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.rept.0625B,
-   author = {{Bonnarel}, F. and {Louys}, M. and {Chilingarian}, I. and {Micol}, A. and 
-	{Richards}, A. and {McDowell}, J.},
-    title = "{Utype list for the Characterisation Data Model Version 1.11}",
-howpublished = {IVOA Note 25 June 2007},
-     year = 2007,
-    month = jun,
-   editor = {{Bonnarel}, F. and {Louys}, M.},
-      doi = {10.5479/ADS/bib/2007ivoa.rept.0625B},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0625B},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Bonnarel}, Fran{\c{c}}ois and {Louys}, Mireille and
+         {Chilingarian}, Igor and {Micol}, Alberto and {Richards}, Anita and
+         {McDowell}, Jonathan},
+        title = "{Utype list for the Characterisation Data Model Version 1.11}",
+ howpublished = {IVOA Note 25 June 2007},
+         year = 2007,
+        month = jun,
+        pages = {625},
+          doi = {10.5479/ADS/bib/2007ivoa.rept.0625B},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0625B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.rept.0618W,
-   author = {{Williams}, R. and {Allen}, M. and {Arviset}, C. and {Derriere}, S. and 
-	{deYoung}, D. and {Dolensky}, M. and {Genova}, F. and {Graham}, M. and 
-	{Hanisch}, B. and {Lemson}, G. and {Louys}, M. and {Preite Martinez}, A. and 
-	{Noddle}, K. and {Ochsenbein}, F. and {Osuna}, P. and {Plante}, R. and 
-	{Richards}, A. and {Seaman}, R. and {Shirasaki}, Y. and {Stebe}, A. and 
-	{Taylor}, M. and {Wozniak}, H.},
-    title = "{The IVOA in 2007: Assessment, Future Roadmap Version 1.00}",
-howpublished = {IVOA Note 18 June 2007},
-     year = 2007,
-    month = jun,
-      doi = {10.5479/ADS/bib/2007ivoa.rept.0618W},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0618W},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Williams}, Roy and {Allen}, Mark and {Arviset}, Christophe and
+         {Derriere}, Sebastien and {deYoung}, Dave and {Dolensky}, Markus and
+         {Genova}, Francoise and {Graham}, Matthew and {Hanisch}, Bob and
+         {Lemson}, Gerard and {Louys}, Mireille and {Preite Martinez}, Andrea and
+         {Noddle}, Keith and {Ochsenbein}, Francois and {Osuna}, Petdro and
+         {Plante}, Ray and {Richards}, Anita and {Seaman}, Rob and
+         {Shirasaki}, Yuji and {Stebe}, Aurelien and {Taylor}, Mark and
+         {Wozniak}, Herve},
+        title = "{The IVOA in 2007: Assessment, Future Roadmap Version 1.00}",
+ howpublished = {IVOA Note 18 June 2007},
+         year = 2007,
+        month = jun,
+        pages = {618},
+          doi = {10.5479/ADS/bib/2007ivoa.rept.0618W},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.rept.0618W},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.0402M,
-   author = {{Preite Martinez}, A. and {Derriere}, S. and {Delmotte}, N. and 
-	{Gray}, N. and {Mann}, R. and {McDowell}, J. and {Mc Glynn}, T. and 
-	{Ochsenbein}, F. and {Osuna}, P. and {Rixon}, G. and {Williams}, R.
-	},
-    title = "{The UCD1+ controlled vocabulary Version 1.23}",
-howpublished = {IVOA Recommendation 02 April 2007},
-     year = 2007,
-    month = apr,
-archivePrefix = "arXiv",
-   eprint = {1110.0518},
- primaryClass = "astro-ph.IM",
-   editor = {{Preite Martinez}, A. and {Derriere}, S.},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.0402M},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.0402M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Preite Martinez}, Andrea and {Derriere}, Sebastien and
+         {Delmotte}, Nausicaa and {Gray}, Norman and {Mann}, Robert and
+         {McDowell}, Jonathan and {Mc Glynn}, Thomas and
+         {Ochsenbein}, Fran{\c{c}}ois and {Osuna}, Pedro and {Rixon}, Guy and
+         {Williams}, Roy},
+        title = "{The UCD1+ controlled vocabulary Version 1.23}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 02 April 2007},
+         year = 2007,
+        month = apr,
+        pages = {402},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.0402M},
+archivePrefix = {arXiv},
+       eprint = {1110.0518},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.0402M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.0314P,
-   author = {{Plante}, R. and {Linde}, T. and {Williams}, R. and {Noddle}, K.
-	},
-    title = "{IVOA Identifiers Version 1.12}",
-howpublished = {IVOA Recommendation 14 March 2007},
-     year = 2007,
-    month = mar,
-archivePrefix = "arXiv",
-   eprint = {1110.0512},
- primaryClass = "astro-ph.IM",
-   editor = {{Plante}, R.},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.0314P},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.0314P},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Plante}, Raymond and {Linde}, Tony and {Williams}, Roy and
+         {Noddle}, Keith},
+        title = "{IVOA Identifiers Version 1.12}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 14 March 2007},
+         year = 2007,
+        month = mar,
+        pages = {314},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.0314P},
+archivePrefix = {arXiv},
+       eprint = {1110.0512},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.0314P},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2007ivoa.spec.0302H,
-   author = {{Hanisch}, R. and {IVOA Resource Registry Working Group} and 
-	{NVO Metadata Working Group}},
-    title = "{Resource Metadata for the Virtual Observatory Version 1.12}",
-howpublished = {IVOA Recommendation 02 March 2007},
-     year = 2007,
-    month = mar,
-archivePrefix = "arXiv",
-   eprint = {1110.0514},
- primaryClass = "astro-ph.IM",
-   editor = {{Hanisch}, R.},
-      doi = {10.5479/ADS/bib/2007ivoa.spec.0302H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.0302H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Hanisch}, Robert and {IVOA Resource Registry Working Group} and
+         {NVO Metadata Working Group}},
+        title = "{Resource Metadata for the Virtual Observatory Version 1.12}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 02 March 2007},
+         year = 2007,
+        month = mar,
+        pages = {302},
+          doi = {10.5479/ADS/bib/2007ivoa.spec.0302H},
+archivePrefix = {arXiv},
+       eprint = {1110.0514},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2007ivoa.spec.0302H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2006ivoa.spec.1101S,
-   author = {{Seaman}, R. and {Williams}, R. and {Allan}, A. and {Barthelmy}, S. and 
-	{Bloom}, J. and {Graham}, M. and {Hessman}, F. and {Marka}, S. and 
-	{Rots}, A. and {Stoughton}, C. and {Vestrand}, T. and {White}, R. and 
-	{Wozniak}, P.},
-    title = "{Sky Event Reporting Metadata (VOEvent) Version 1.11}",
-howpublished = {IVOA Recommendation 1 November 2006},
-     year = 2006,
-    month = nov,
-   editor = {{Seaman}, R. and {Williams}, R.},
-      doi = {10.5479/ADS/bib/2006ivoa.spec.1101S},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.spec.1101S},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Seaman}, Rob and {Williams}, Roy and {Allan}, Alasdair and
+         {Barthelmy}, Scott and {Bloom}, Joshua and {Graham}, Matthew and
+         {Hessman}, Frederic and {Marka}, Szabolcs and {Rots}, Arnold and
+         {Stoughton}, Chris and {Vestrand}, Tom and {White}, Robert and
+         {Wozniak}, Przemyslaw},
+        title = "{Sky Event Reporting Metadata (VOEvent) Version 1.11}",
+ howpublished = {IVOA Recommendation 1 November 2006},
+         year = 2006,
+        month = nov,
+        pages = {1101},
+          doi = {10.5479/ADS/bib/2006ivoa.spec.1101S},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.spec.1101S},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2006ivoa.rept.0919C,
-   author = {{Christensen}, L.~L. and {Hurt}, R. and {Gauthier}, A. and {IAU Virtual Repository Working Group}
-	},
-    title = "{Astronomical Outreach Imagery Metadata Tags for the Virtual Observatory Version 1.00}",
-howpublished = {IVOA Note 19 September 2006},
-     year = 2006,
-    month = sep,
-   editor = {{Christensen}, L.~L. and {Hurt}, R.},
-      doi = {10.5479/ADS/bib/2006ivoa.rept.0919C},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.rept.0919C},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Christensen}, Lars Lindberg and {Hurt}, Robert and
+         {Gauthier}, Adrienne and {IAU Virtual Repository Working Group}},
+        title = "{Astronomical Outreach Imagery Metadata Tags for the Virtual Observatory Version 1.00}",
+ howpublished = {IVOA Note 19 September 2006},
+         year = 2006,
+        month = sep,
+        pages = {919},
+          doi = {10.5479/ADS/bib/2006ivoa.rept.0919C},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.rept.0919C},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2006ivoa.rept.0606A,
-   author = {{Allen}, M. and {Genova}, F. and {Hanisch}, B. and {Lemson}, G. and 
-	{Linde}, T. and {McDowell}, J. and {Moore}, R. and {Nieto-Santisteban}, M. and 
-	{Ochsenbein}, F. and {Ohishi}, M. and {Preite Martinez}, A. and 
-	{Rixon}, G. and {Shirasaki}, Y. and {Tody}, D. and {Williams}, R.
-	},
-    title = "{The IVOA in 2006: Assessment, Future Roadmap Version 1.00}",
-howpublished = {IVOA Note 06 June 2006},
-     year = 2006,
-    month = jun,
-   editor = {{Allen}, M. and {Genova}, F. and {Hanisch}, B. and {Lemson}, G. and 
-	{Linde}, T. and {McDowell}, J. and {Moore}, R. and {Nieto-Santisteban}, M. and 
-	{Ochsenbein}, F. and {Ohishi}, M. and {Preite Martinez}, A. and 
-	{Rixon}, G. and {Shirasaki}, Y. and {Tody}, D.},
-      doi = {10.5479/ADS/bib/2006ivoa.rept.0606A},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.rept.0606A},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Allen}, Mark and {Genova}, Francoise and {Hanisch}, Bob and
+         {Lemson}, Gerard and {Linde}, Tony and {McDowell}, Jonathan and
+         {Moore}, Reagan and {Nieto-Santisteban}, Maria and
+         {Ochsenbein}, Francois and {Ohishi}, Masatoshi and
+         {Preite Martinez}, Andrea and {Rixon}, Guy and {Shirasaki}, Yuji and
+         {Tody}, Doug and {Williams}, Roy},
+        title = "{The IVOA in 2006: Assessment, Future Roadmap Version 1.00}",
+ howpublished = {IVOA Note 06 June 2006},
+         year = 2006,
+        month = jun,
+        pages = {606},
+          doi = {10.5479/ADS/bib/2006ivoa.rept.0606A},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.rept.0606A},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2006ivoa.spec.0528M,
-   author = {{Preite Martinez}, A. and {Derriere}, S. and {Delmotte}, N. and 
-	{Derriere}, S. and {Gray}, N. and {Mann}, R. and {McDowell}, J. and 
-	{Mc Glynn}, T. and {Ochsenbein}, F. and {Osuna}, P. and {Preite Martinez}, A. and 
-	{Rixon}, G. and {Williams}, R.},
-    title = "{Maintenance of the list of UCD words Version 1.20}",
-howpublished = {IVOA Recommendation 28 May 2006},
-     year = 2006,
-    month = may,
-archivePrefix = "arXiv",
-   eprint = {1110.0519},
- primaryClass = "astro-ph.IM",
-   editor = {{Preite Martinez}, A. and {Derriere}, S.},
-      doi = {10.5479/ADS/bib/2006ivoa.spec.0528M},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.spec.0528M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Preite Martinez}, A. and {Derriere}, S. and {Delmotte}, Nausicaa and
+         {Derriere}, Sebastien and {Gray}, Norman and {Mann}, Robert and
+         {McDowell}, Jonathan and {Mc Glynn}, Thomas and
+         {Ochsenbein}, Fran{\c{c}}ois and {Osuna}, Pedro and
+         {Preite Martinez}, Andrea and {Rixon}, Guy and {Williams}, Roy},
+        title = "{Maintenance of the list of UCD words Version 1.20}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 28 May 2006},
+         year = 2006,
+        month = may,
+        pages = {528},
+          doi = {10.5479/ADS/bib/2006ivoa.spec.0528M},
+archivePrefix = {arXiv},
+       eprint = {1110.0519},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2006ivoa.spec.0528M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2005ivoa.spec.1231D,
-   author = {{Derriere}, S. and {Preite Martinez}, A. and {Preite Martinez}, A. and 
-	{Derriere}, S. and {Gray}, N. and {Mann}, R. and {McDowell}, J. and 
-	{Mc Glynn}, T. and {Ochsenbein}, F. and {Osuna}, P. and {Rixon}, G. and 
-	{Williams}, R.},
-    title = "{The UCD1+ controlled vocabulary Version 1.11}",
-howpublished = {IVOA Recommendation 31 December 2005},
-     year = 2005,
-    month = dec,
-   editor = {{Derriere}, S. and {Preite Martinez}, A.},
-      doi = {10.5479/ADS/bib/2005ivoa.spec.1231D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2005ivoa.spec.1231D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Derriere}, S. and {Preite Martinez}, A. and {Preite Martinez}, Andrea and
+         {Derriere}, S{\'e}bastien and {Gray}, Norman and {Mann}, Robert and
+         {McDowell}, Jonathan and {Mc Glynn}, Thomas and
+         {Ochsenbein}, Fran{\c{c}}ois and {Osuna}, Pedro and {Rixon}, Guy and
+         {Williams}, Roy},
+        title = "{The UCD1+ controlled vocabulary Version 1.11}",
+ howpublished = {IVOA Recommendation 31 December 2005},
+         year = 2005,
+        month = dec,
+        pages = {1231},
+          doi = {10.5479/ADS/bib/2005ivoa.spec.1231D},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2005ivoa.spec.1231D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2005ivoa.spec.0819D,
-   author = {{Derriere}, S. and {Preite Martinez}, A. and {Williams}, R. and 
-	{Gray}, N. and {Mann}, R. and {McDowell}, J. and {Mc Glynn}, T. and 
-	{Ochsenbein}, F. and {Osuna}, P. and {Rixon}, G.},
-    title = "{An IVOA Standard for Unified Content Descriptors Version 1.10}",
-howpublished = {IVOA Recommendation 19 August 2005},
-     year = 2005,
-    month = aug,
-archivePrefix = "arXiv",
-   eprint = {1110.0525},
- primaryClass = "astro-ph.IM",
-   editor = {{Derriere}, S. and {Preite Martinez}, A. and {Williams}, R.},
-      doi = {10.5479/ADS/bib/2005ivoa.spec.0819D},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2005ivoa.spec.0819D},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Derriere}, S{\'e}bastien and {Preite Martinez}, Andrea and
+         {Williams}, Roy and {Gray}, Norman and {Mann}, Robert and
+         {McDowell}, Jonathan and {Mc Glynn}, Thomas and
+         {Ochsenbein}, Fran{\c{c}}ois and {Osuna}, Pedro and {Rixon}, Guy},
+        title = "{An IVOA Standard for Unified Content Descriptors Version 1.10}",
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ howpublished = {IVOA Recommendation 19 August 2005},
+         year = 2005,
+        month = aug,
+        pages = {819},
+          doi = {10.5479/ADS/bib/2005ivoa.spec.0819D},
+archivePrefix = {arXiv},
+       eprint = {1110.0525},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2005ivoa.spec.0819D},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2005ivoa.rept.0808W,
-   author = {{Williams}, R.},
-    title = "{The IVOA in 2005: Assessment, Future Roadmap Version 1.00}",
-howpublished = {IVOA Note 08 August 2005},
-     year = 2005,
-    month = aug,
-   editor = {{Williams}, R.},
-      doi = {10.5479/ADS/bib/2005ivoa.rept.0808W},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2005ivoa.rept.0808W},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Williams}, Roy},
+        title = "{The IVOA in 2005: Assessment, Future Roadmap Version 1.00}",
+ howpublished = {IVOA Note 08 August 2005},
+         year = 2005,
+        month = aug,
+        pages = {808},
+          doi = {10.5479/ADS/bib/2005ivoa.rept.0808W},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2005ivoa.rept.0808W},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2004ivoa.spec.0811O,
-   author = {{Ochsenbein}, F. and {Williams}, R. and {Davenhall}, C. and 
-	{Durand}, D. and {Fernique}, P. and {Giaretta}, D. and {Hanisch}, R. and 
-	{McGlynn}, T. and {Szalay}, A. and {Taylor}, M.~B. and {Wicenec}, A.
-	},
-    title = "{VOTable Format Definition Version 1.1}",
-howpublished = {IVOA Recommendation 11 August 2004},
-     year = 2004,
-    month = aug,
-   editor = {{Ochsenbein}, F.},
-      doi = {10.5479/ADS/bib/2004ivoa.spec.0811O},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2004ivoa.spec.0811O},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Ochsenbein}, Fran{\c{c}}ois and {Williams}, Roy and {Davenhall}, Clive and
+         {Durand}, Daniel and {Fernique}, Pierre and {Giaretta}, David and
+         {Hanisch}, Robert and {McGlynn}, Tom and {Szalay}, Alex and
+         {Taylor}, Mark B. and {Wicenec}, Andreas},
+        title = "{VOTable Format Definition Version 1.1}",
+ howpublished = {IVOA Recommendation 11 August 2004},
+         year = 2004,
+        month = aug,
+        pages = {811},
+          doi = {10.5479/ADS/bib/2004ivoa.spec.0811O},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2004ivoa.spec.0811O},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2004ivoa.spec.0426H,
-   author = {{Hanisch}, R. and {IVOA Resource Registry Working Group} and 
-	{NVO Metadata Working Group}},
-    title = "{Resource Metadata for the Virtual Observatory Version 1.01}",
-howpublished = {IVOA Recommendation 26 April 2004},
-     year = 2004,
-    month = apr,
-   editor = {{Hanisch}, R.},
-      doi = {10.5479/ADS/bib/2004ivoa.spec.0426H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2004ivoa.spec.0426H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Hanisch}, Robert and {IVOA Resource Registry Working Group} and
+         {NVO Metadata Working Group}},
+        title = "{Resource Metadata for the Virtual Observatory Version 1.01}",
+ howpublished = {IVOA Recommendation 26 April 2004},
+         year = 2004,
+        month = apr,
+        pages = {426},
+          doi = {10.5479/ADS/bib/2004ivoa.spec.0426H},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2004ivoa.spec.0426H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2004ivoa.rept.0315H,
-   author = {{Hanisch}, B. and {Quinn}, P. and {Lawrence}, A.},
-    title = "{The Management, Storage, Utilization of Astronomical Data in the 21st Century Version 1.00}",
-howpublished = {IVOA Note 15 March 2004},
-     year = 2004,
-    month = mar,
-   editor = {{Hanisch}, B.},
-      doi = {10.5479/ADS/bib/2004ivoa.rept.0315H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2004ivoa.rept.0315H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Hanisch}, Bob and {Quinn}, Peter and {Lawrence}, Andy},
+        title = "{The Management, Storage, Utilization of Astronomical Data in the 21st Century Version 1.00}",
+ howpublished = {IVOA Note 15 March 2004},
+         year = 2004,
+        month = mar,
+        pages = {315},
+          doi = {10.5479/ADS/bib/2004ivoa.rept.0315H},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2004ivoa.rept.0315H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
 @MISC{2003ivoa.spec.1024H,
-   author = {{Hanisch}, R.~J. and {Linde}, A.~E. and {Executive Committee}, I.
-	},
-    title = "{IVOA Document Standards Version 1.0}",
-howpublished = {IVOA Recommendation 24 October 2003},
-     year = 2003,
-    month = oct,
-   editor = {{Hanisch}, R.~J. and {Linde}, A.~E.},
-      doi = {10.5479/ADS/bib/2003ivoa.spec.1024H},
-   adsurl = {https://ui.adsabs.harvard.edu/abs/2003ivoa.spec.1024H},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+       author = {{Hanisch}, R.~J. and {Linde}, A.~E. and {Executive Committee}, IVOA},
+        title = "{IVOA Document Standards Version 1.0}",
+ howpublished = {IVOA Recommendation 24 October 2003},
+         year = 2003,
+        month = oct,
+        pages = {1024},
+          doi = {10.5479/ADS/bib/2003ivoa.spec.1024H},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2003ivoa.spec.1024H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 


### PR DESCRIPTION
This also pulls in the latest version for docrepo.bib from upstream
ivoatex (this should probably become a git submodule)

It also does a few citation style fixes; ivoatex doesn't really support
multi-argument citep, and you shouldn't use cite in ivoatex or natbib in
general; do either citet or citep.

I think seb2010-1 was never published, was it?

Also, I don't think you have a local bibliography, so I removed the
reference to it from the bibliography arguments.  If you actually need
one, my advice would be to call it local.bib to avoid potential
confusion.