### PR TITLE
Photcal GROUP utype

### DIFF
--- a/TimeSeries.tex
+++ b/TimeSeries.tex
@@ -204,10 +204,11 @@ following mandatory terms:
      \item[\attr{DESCRIPTION}] This attribute is used to describe the
        \texttt{PHOTCAL} \elem{GROUP}. This attribute is optional, but
        recommended.
-     \item[\attrval{utype}{timeseries:PhotometryPoint}]\todo{Something
-       ought to be here, if nothing else the relation of this to the
-       fixed name.\ada{do we need it, we could drop it since there is
-         the PARAM with the Obscore type/subtype}} \dots
+     \item[\attrval{utype}{PhotDM:PhotCal}] utype inherited from PhotDM.
+       %\todo{Something
+       %ought to be here, if nothing else the relation of this to the
+       %fixed name.\ada{do we need it, we could drop it since there is
+       %  the PARAM with the Obscore type/subtype}} \dots
 \end{description}
 
 The attributes of this \elem{GROUP} are defined as \elem{PARAM}s

--- a/photcal_PARAM.xml
+++ b/photcal_PARAM.xml
@@ -1,5 +1,5 @@
 <GROUP name="photcal" ID="phot_sys" ucd="phot" 
-       utype="timeseries:PhotometryPoint" > 
+       utype="PhotDM:PhotCal" > 
        <DESCRIPTION>Photometric system description </DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
               utype="photDM:PhotometryFilter.identifier" 

--- a/table_TIMESERIES.xml
+++ b/table_TIMESERIES.xml
@@ -2,9 +2,9 @@
   <DESCRIPTION>Light curve in my favorite filter  </DESCRIPTION>
   <PARAM name="dataproduct_type" ucd="meta.code.class" 
          utype="obscore:ObsDataset.dataProductType" datatype="char" 
-         arraysize="*"  unit="" value="timeseries" />
+         arraysize="*"  value="timeseries" />
   <PARAM name="dataproduct_subtype" ucd="meta.code.class" 
          utype="obscore:ObsDataset.dataProductSubtype" datatype="char" 
-         arraysize="*" unit="" value="lightcurve" />
+         arraysize="*" value="lightcurve" />
   <!-- perhaps more PARAMs, then COLUMNs and data -->
 </TABLE>

--- a/table_TIMESERIES.xml
+++ b/table_TIMESERIES.xml
@@ -1,5 +1,6 @@
 <TABLE name="mytable" 
-  <DESCRIPTION>Light curve in my favorite filter  </DESCRIPTION>
+  <DESCRIPTION>Light curve showing an eclipse for SDSSJ121258.25-012310.1
+  </DESCRIPTION>
   <PARAM name="dataproduct_type" ucd="meta.code.class" 
          utype="obscore:ObsDataset.dataProductType" datatype="char" 
          arraysize="*"  value="timeseries" />

--- a/vot-ex1-GROUP.xml
+++ b/vot-ex1-GROUP.xml
@@ -4,7 +4,7 @@
 <TIMESYS ID="timesys" refposition="HELIOCENTER" 
          timeorigin="0" timescale="UNKOWN"/>
 <GROUP name="photcal" ID="phot_sys" ucd="phot" 
-       utype="timeseries:PhotometryPoint" > 
+       utype="PhotDM:PhotCal" > 
        <DESCRIPTION>Photometric system description </DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
               utype="photDM:PhotometryFilter.identifier" 
@@ -26,7 +26,7 @@
 <DESCRIPTION>Light curve in filter zg </DESCRIPTION>
 <PARAM name="dataproduct_type" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductType" datatype="char" 
-       arraysize="*"  unit="" value="timeseries" />
+       arraysize="*"  value="timeseries" />
 <PARAM name="dataproduct_subtype" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductSubtype" datatype="char" 
        arraysize="*" unit="" value="lightcurve" />

--- a/vot-ex2-GROUP.xml
+++ b/vot-ex2-GROUP.xml
@@ -4,7 +4,7 @@
 <TIMESYS ID="time_frame" refposition="BARYCENTER" 
          timeorigin="2455197.5" timescale="TCB"/>
 <GROUP name="photcal" ID="phot_sys-G" ucd="phot" 
-       utype="timeseries:PhotometryPoint" > 
+       utype="PhotDM:PhotCal" > 
        <DESCRIPTION>GAIA G filter, DR2</DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
               utype="photDM:PhotometryFilter.identifier" 
@@ -20,7 +20,7 @@
               datatype="float" unit="Angstrom" value="6230.0"/>
 </GROUP>
 <GROUP name="photcal" ID="phot_sys-Gbp" ucd="phot" 
-       utype="timeseries:PhotometryPoint" > 
+       utype="PhotDM:PhotCal" > 
        <DESCRIPTION>GAIA Gbp filter, DR2</DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
               utype="photDM:PhotometryFilter.identifier" 
@@ -36,7 +36,7 @@
               datatype="float" unit="Angstrom" value="5050.0"/>
 </GROUP>
 <GROUP name="photcal" ID="phot_sys-Grp" ucd="phot" 
-       utype="timeseries:PhotometryPoint" > 
+       utype="PhotDM:PhotCal" > 
        <DESCRIPTION>GAIA Grp filter, DR2</DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
               utype="photDM:PhotometryFilter.identifier" 
@@ -58,10 +58,10 @@
 <DESCRIPTION>Light curve in filter G </DESCRIPTION>
 <PARAM name="dataproduct_type" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductType" datatype="char" 
-       arraysize="*"  unit="" value="timeseries" />
+       arraysize="*" value="timeseries" />
 <PARAM name="dataproduct_subtype" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductSubtype" datatype="char" 
-       arraysize="*" unit="" value="lightcurve" />
+       arraysize="*" value="lightcurve" />
 <FIELD datatype="double" name="obs_time" ucd="time.epoch" unit="d" 
        ref="time_frame"/>
 <FIELD datatype="float" name="flux" ucd="phot.flux;em.opt" 
@@ -81,10 +81,10 @@
        <DESCRIPTION>Light curve in filter Gbp </DESCRIPTION>
 <PARAM name="dataproduct_type" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductType" datatype="char" 
-       arraysize="*"  unit="" value="timeseries" />
+       arraysize="*" value="timeseries" />
 <PARAM name="dataproduct_subtype" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductSubtype" datatype="char" 
-       arraysize="*" unit="" value="lightcurve" />
+       arraysize="*" value="lightcurve" />
 <FIELD datatype="double" name="obs_time" ucd="time.epoch" unit="d" 
        ref="time_frame"/>
 <FIELD datatype="float" name="flux" ucd="phot.flux;em.opt.V" 
@@ -104,10 +104,10 @@
        <DESCRIPTION>Light curve in filter Grp </DESCRIPTION>
 <PARAM name="dataproduct_type" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductType" datatype="char" 
-       arraysize="*"  unit="" value="timeseries" />
+       arraysize="*" value="timeseries" />
 <PARAM name="dataproduct_subtype" ucd="meta.code.class" 
        utype="obscore:ObsDataset.dataProductSubtype" datatype="char" 
-       arraysize="*" unit="" value="lightcurve" />
+       arraysize="*" value="lightcurve" />
 <FIELD datatype="double" name="obs_time" ucd="time.epoch" unit="d" 
        ref="time_frame"/>
 <FIELD datatype="float" name="flux" ucd="phot.flux;em.opt.R" 


### PR DESCRIPTION
The GROUP Photcal had the utype set to `timeseries:PhotometryPoint`, but this was incorrect, this has now been changed to `PhotDM:PhotCal` in agreement with and inherited from PhotDM. This changes fix that in the examples and the text.