### PR TITLE
fix case for name="PHOTCAL" in examples

### DIFF
--- a/photcal_PARAM.xml
+++ b/photcal_PARAM.xml
@@ -1,4 +1,4 @@
-<GROUP name="photcal" ID="phot_sys" ucd="phot" 
+<GROUP name="PHOTCAL" ID="phot_sys" ucd="phot" 
        utype="PhotDM:PhotCal" > 
        <DESCRIPTION>Photometric system description </DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 

--- a/vot-ex1-GROUP.xml
+++ b/vot-ex1-GROUP.xml
@@ -3,7 +3,7 @@
 <COOSYS ID="ICRS" system="ICRS"  epoch="J2015"/>
 <TIMESYS ID="timesys" refposition="HELIOCENTER" 
          timeorigin="0" timescale="UNKNOWN"/>
-<GROUP name="photcal" ID="phot_sys" ucd="phot" 
+<GROUP name="PHOTCAL" ID="phot_sys" ucd="phot" 
        utype="PhotDM:PhotCal" > 
        <DESCRIPTION>Photometric system description </DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 

--- a/vot-ex2-GROUP.xml
+++ b/vot-ex2-GROUP.xml
@@ -3,7 +3,7 @@
 <COOSYS ID="system" epoch="J2015.5" system="ICRS"/>
 <TIMESYS ID="time_frame" refposition="BARYCENTER" 
          timeorigin="2455197.5" timescale="TCB"/>
-<GROUP name="photcal" ID="phot_sys-G" ucd="phot" 
+<GROUP name="PHOTCAL" ID="phot_sys-G" ucd="phot" 
        utype="PhotDM:PhotCal" > 
        <DESCRIPTION>GAIA G filter, DR2</DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
@@ -19,7 +19,7 @@
               utype="photDM:PhotometryFilter.spectralLocation.value" 
               datatype="float" unit="Angstrom" value="6230.0"/>
 </GROUP>
-<GROUP name="photcal" ID="phot_sys-Gbp" ucd="phot" 
+<GROUP name="PHOTCAL" ID="phot_sys-Gbp" ucd="phot" 
        utype="PhotDM:PhotCal" > 
        <DESCRIPTION>GAIA Gbp filter, DR2</DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 
@@ -35,7 +35,7 @@
               utype="photDM:PhotometryFilter.spectralLocation.value" 
               datatype="float" unit="Angstrom" value="5050.0"/>
 </GROUP>
-<GROUP name="photcal" ID="phot_sys-Grp" ucd="phot" 
+<GROUP name="PHOTCAL" ID="phot_sys-Grp" ucd="phot" 
        utype="PhotDM:PhotCal" > 
        <DESCRIPTION>GAIA Grp filter, DR2</DESCRIPTION>
        <PARAM name="filterIdentifier" ucd="meta.id;instr.filter" 


### PR DESCRIPTION
The text says that the photcal GROUP is identified with

   name="PHOTCAL"

but most (all?) the examples had

   name="photcal"

We should not assume case-insensitivity for this,
so I've fixed the examples accordingly.  If you think it should be
name="photcal" passim, feel free to change the text instead.